### PR TITLE
Add support for monero generate_key_derivation and subaddress/output …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+project(monero-crypto)
+include(intree.cmake)
+
+add_library(monero-crypto $<TARGET_OBJECTS:monero-crypto-intree>)
+
+INSTALL(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/monero/crypto/${MONERO_CRYPTO_LIBRARY}.h" DESTINATION "include/monero/crypto")
+INSTALL(FILES "${CMAKE_BINARY_DIR}/include/monero/crypto.h" DESTINATION "include/monero")
+INSTALL(TARGETS monero-crypto LIBRARY)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,125 @@
-# supercop
+# Supercop
+
+> This project could use a rename :/
+
+The objective of this project is to provide fast cryptographic operations for
+Monero wallets. Unfortunately, there isn't necessarily a single fastest library
+for all platforms - donna64 for instance likely performs poorly when
+cross-compiled to asm.js or 32-bit arm. This project mitigates this issue by
+copying the cryptographic libraries with as little changes as possible (ideally
+zero), and then provides smaller and easier to audit "glue" functions that use
+the cryptographic library to perform typical Monero wallet tasks. These "glue"
+functions are often not obvious to the typical developer (otherwise they would
+be using the cryptographic libraries already), however auditing these functions
+should be straightforward to anyone familar with how the cryptography works.
+
+The project is also designed to be used in-tree in other projects or installable
+on a system. The default Monero wallets use the in-tree implementation which
+serve as a more complex example of its usage. The project directory structure:
+
+  - **crypto_sign** - whose name is taken from supercop. The code in here is
+    from upstream cryptographic libraries with minimal changes (position
+    independent ASM).
+  - **include** - The only files that should be included by external projects,
+    with the exception of the auto-generated header.
+  - **src** - Contains all of the glue functions and build code.
+  - **functions.cmake** - The raw components for building the library. Used by
+    the default Monero wallet.
+  - **intree.cmake** - Creates a cmake library target `monero-crypto-intree`
+    and generates a header at `<BUILD_LOCATION>/include/monero/crypto.h`.
+  - **CMakeLists.txt** - Declares a new project for creating/installing a
+    shared or static `monero-crypto` library.
+
+> Downstream projects cannot currently use this project _without_ also using
+> the `monero-project/monero/src/crypto/crypto.h` functions - specifically
+> `crypto::derivation_to_scalar`. So currently this project provides
+> performance enhancements but not standalone usage.
+
+## Usage
+
+Every cryptographic library implements the same function signatures but with
+unique namespaces to avoid collisions in the C symbol table. Downstream
+projects can either use a specific library and header file OR dynamically
+select a library and use a cmake generated header that uses macro replacement
+to reference the selected library. Since each library has unique symbol names,
+multiple can be used simulatenously (benchmarking, etc).
+
+## C Wallet Functions
+
+Every cryptographic library implements:
+
+  - **`monero_crypto_<namespace>_scalarmult(char* out, const char* pub, const char* sec)`** -
+    where `out` is the shared secret, `pub` is an ed25519 public key, and `sec`
+    is a user secret key. This operation is a standard ECDH operation on the
+    ed25519 curve.
+  - **`monero_crypto_<namespace>_generate_key_derivation(char* out, const char* tx_pub, const char* view_sec)`** -
+    where `out` is the shared secret, `tx_pub` is the public key from the
+    transaction and `view_sec` is the users view-key secret.
+  - **`monero_crypto_<namespace>_generate_subaddress_public_key(char* out, const char* output_pub, const char* special_sec)`** -
+    where `out` is the computed spend-public (primary or subaddress),
+    `output_pub` is the public key from the transaction output, and
+    `special_sec` is the output from `crypto::derivation_to_scalar` (which is
+    given the shared secret from `generate_key_derivation`).
+
+All `char` pointers must be exactly 32-bytes. The auto-generated header has an
+empty namespace for these functions and uses macro replacement to forward to the
+selected library. If using dynamically selected libraries, include the
+auto-generated header and use `monero_crypto_generate_key_derivation`, etc.
+
+## CMake Usage
+### Explicit Library Usage
+A library can be selected explicitly in-tree:
+
+```
+include(supercop/functions.cmake)
+monero_crypto_get_target("amd64-64-24k" CRYPTO_TARGET)
+
+add_library(all $<OBJECT_TARGETS:${CRYPTO_TARGET}> all.cpp)
+add_library(referenced referenced.cpp)
+target_link_libraries(referenced ${CRYPTO_TARGET})
+```
+
+The `all` library will have all C functions in the `amd64-64-24k` library
+whereas the `referenced` library will only have C functions referenced in
+`referenced.cpp`.
+
+## Basic In-Tree Dynamic Usage
+A library can be selected at build time in-tree:
+
+```
+include(supercop/intree.cmake)
+
+add_library(all $<OBJECT_TARGETS:monero-crypto-intree> all.cpp)
+add_library(referenced referenced.cpp)
+target_link_libraries(referenced monero-crypto-intree)
+```
+
+The best available library for the target platform is selected which can be
+overriden with `-DMONERO_CRYPTO_LIBRARY=amd64-51-30k` or by setting the
+variable with the same name.
+
+A header file is written to `<BUILD_LOCATION>/include/monero/crypto.h` which
+contains empty namespace macros that expand to the
+[wallet functions](#c-wallet-functions) for the selected library. Including
+this header file and using the empty namespace macros will allow for the
+crypto library to be selected dynamically.
+
+See the [explicit usage section](#explicit-library-usage) for the difference
+between the `all` and `referenced` libraries.
+
+## Advanced In-Tree Dynamic Usage
+See `intree.cmake` on how to use the individual cmake functions in your project
+for more control. Each of the cmake functions is documented.
+
+## Standalone Usage
+Is not-yet fully functional since the `crypto::derivation_to_scalar` from the
+Monero source tree is still needed. However this is a proof-of-concept that
+will be useful for testing if your project does not use cmake.
+
+Running `cmake <source_path> . && make && sudo make install` will autodetect
+the best crypto library, build it in the current directory, and then install to
+the default location for your system. An error is generated if your target
+platform does not have a supported crypto library. The auto-selected library
+can be overriden with `-DMONERO_CRYPTO_LIBRARY=amd64-51-30k` at the first
+cmake step. Using `-DMONERO_CRYPTO_LIBRARY=invalid` will generate an error
+that displays all available crypto libraries.

--- a/functions.cmake
+++ b/functions.cmake
@@ -1,0 +1,91 @@
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(MONERO_CRYPTO_DIR ${CMAKE_CURRENT_LIST_DIR})
+add_subdirectory("${MONERO_CRYPTO_DIR}/src" ${CMAKE_CURRENT_BINARY_DIR}/monero_crypto_src)
+
+# Set `OUT` to a list of all valid library names.
+function(monero_crypto_libraries OUT)
+  set(${OUT} "amd64-64-24k" "amd64-51-30k" PARENT_SCOPE)
+endfunction (monero_crypto_libraries)
+
+# `OUT` is set to 1 iff `CRYPTO_LIBRARY` is a valid library name.
+function(monero_crypto_valid CRYPTO_LIBRARY OUT)
+  monero_crypto_libraries(ALL_LIBRARIES)
+  list(FIND ALL_LIBRARIES ${CRYPTO_LIBRARY} FOUND)
+  if (FOUND LESS 0)
+    set(${OUT} 0 PARENT_SCOPE)
+  else ()
+    set(${OUT} 1 PARENT_SCOPE)
+  endif ()
+endfunction (monero_crypto_valid)
+
+# Set `OUT` to a valid C/C++ namespace name based on `CRYPTO_LIBRARY`.
+function(monero_crypto_get_namespace CRYPTO_LIBRARY OUT)
+  string(REPLACE "-" "_" TEMP "${CRYPTO_LIBRARY}")
+  set(${OUT} ${TEMP} PARENT_SCOPE)
+endfunction (monero_crypto_get_namespace)
+
+# Set `OUT` to a valid target dependency name based on `CRYPTO_LIBRARY`.
+function(monero_crypto_get_target CRYPTO_LIBRARY OUT)
+  set(${OUT} "monero-crypto-${CRYPTO_LIBRARY}" PARENT_SCOPE)
+endfunction (monero_crypto_get_target)
+
+# Sets `BEST` to the preferred crypto library for the target platform, and
+# sets `AVAILABLE` to all valid crypto libraries for the target platform.
+function(monero_crypto_autodetect AVAILABLE BEST)
+  if (UNIX AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|AMD64.*|x86_64.*")
+    message("Monero crypto autodetect selected \"amd64-64-24k\" for target platform")
+    set(${AVAILABLE} "amd64-64-24k" "amd64-51-30k" PARENT_SCOPE)
+    set(${BEST} "amd64-64-24k" PARENT_SCOPE)
+  else ()
+    message("Monero crypto autodetect failed to find library for target platform")
+    unset(${AVAILABLE} PARENT_SCOPE)
+    unset(${BEST} PARENT_SCOPE)
+  endif ()
+endfunction (monero_crypto_autodetect)
+
+# Writes a C header to `HEADER_FILE` that contains these C functions:
+#   - `monero_crypto_generate_key_derivation`
+#   - `monero_crypto_derive_subaddress_public_key`
+# that map to the selected `CRYPTO_LIBRARY` implementation using macro
+# replacement. See README.md for function explanation.
+#
+# A fatal error is generated if `CRYPTO_LIBRARY` is not valid - linking will
+# always fails in this situation.
+function(monero_crypto_generate_header MONERO_CRYPTO_LIBRARY HEADER_FILE)
+  monero_crypto_valid(${MONERO_CRYPTO_LIBRARY} VALID)
+  if (NOT VALID)
+    monero_crypto_libraries(ALL_LIBRARIES)
+    string(REPLACE ";" " " ALL_LIBRARIES "${ALL_LIBRARIES}")
+    message(FATAL_ERROR "Library ${MONERO_CRYPTO_LIBRARY} is not valid. Must be one of: ${ALL_LIBRARIES}")
+  endif ()
+  monero_crypto_get_namespace(${MONERO_CRYPTO_LIBRARY} MONERO_CRYPTO_NAMESPACE)
+  configure_file("${MONERO_CRYPTO_DIR}/src/crypto.h.in" ${HEADER_FILE})
+endfunction (monero_crypto_generate_header)
+

--- a/include/monero/crypto/amd64-51-30k.h
+++ b/include/monero/crypto/amd64-51-30k.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MONERO_CRYPTO_AMD64_51_30K_H
+#define MONERO_CRYPTO_AMD64_51_30K_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  int monero_crypto_amd64_51_30k_ge25519_scalarmult(char* out, char const* pub, char const* sec);
+  int monero_crypto_amd64_51_30k_generate_key_derivation(char* out, char const* tx_pub, char const* view_sec);
+  int monero_crypto_amd64_51_30k_generate_subaddress_public_key(char* out, char const* output_pub, char const* special_sec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MONERO_CRYPTO_AMD64_51_30K_H

--- a/include/monero/crypto/amd64-64-24k.h
+++ b/include/monero/crypto/amd64-64-24k.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MONERO_CRYPTO_AMD64_64_24K_H
+#define MONERO_CRYPTO_AMD64_64_24K_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  int monero_crypto_amd64_64_24k_ge25519_scalarmult(char* out, char const* pub, char const* sec);
+  int monero_crypto_amd64_64_24k_generate_key_derivation(char* out, char const* tx_pub, char const* view_sec);
+  int monero_crypto_amd64_64_24k_generate_subaddress_public_key(char* out, char const* output_pub, char const* special_sec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MONERO_CRYPTO_AMD64_64_24K_H

--- a/intree.cmake
+++ b/intree.cmake
@@ -1,0 +1,46 @@
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(functions.cmake)
+
+set(MONERO_CRYPTO_LIBRARY "auto" CACHE STRING "Select a crypto library backend")
+
+if (${MONERO_CRYPTO_LIBRARY} STREQUAL "auto")
+  monero_crypto_autodetect(AVAILABLE BEST)
+  if (NOT DEFINED BEST)
+    message(FATAL_ERROR "No crypto library available for target platform")
+  endif ()
+  set(MONERO_CRYPTO_LIBRARY ${BEST})
+endif ()
+
+# next line fatal errors if invalid library selected
+monero_crypto_generate_header(${MONERO_CRYPTO_LIBRARY} "${CMAKE_BINARY_DIR}/include/monero/crypto.h")
+
+monero_crypto_get_target(${MONERO_CRYPTO_LIBRARY} CRYPTO_TARGET)
+add_library(monero-crypto-intree ALIAS ${CRYPTO_TARGET})
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Only build libraries when targeted
+add_subdirectory(amd64 EXCLUDE_FROM_ALL)

--- a/src/amd64/CMakeLists.txt
+++ b/src/amd64/CMakeLists.txt
@@ -1,0 +1,82 @@
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+enable_language(ASM-ATT)
+
+function(add_amd64_library LIBNAME LIBFOLDER)
+  set(MULTIVARS SOURCES)
+  cmake_parse_arguments(AMD64_PERF "" "" "${MULTIVARS}" ${ARGN})
+
+  add_library("monero-crypto-${LIBNAME}" OBJECT
+    "${LIBNAME}.c" "${LIBNAME}-choose_tp.s"
+    "${LIBFOLDER}/choose_t.s"
+    "${LIBFOLDER}/consts.s"
+    "${LIBFOLDER}/fe25519_getparity.c"
+    "${LIBFOLDER}/fe25519_freeze.s"
+    "${LIBFOLDER}/fe25519_invert.c"
+    "${LIBFOLDER}/fe25519_iseq.c"
+    "${LIBFOLDER}/fe25519_mul.s"
+    "${LIBFOLDER}/fe25519_neg.c"
+    "${LIBFOLDER}/fe25519_pack.c"
+    "${LIBFOLDER}/fe25519_pow2523.c"
+    "${LIBFOLDER}/fe25519_setint.c"
+    "${LIBFOLDER}/fe25519_square.s"
+    "${LIBFOLDER}/fe25519_unpack.c"
+    "${LIBFOLDER}/ge25519_add.c"
+    "${LIBFOLDER}/ge25519_add_p1p1.s"
+    "${LIBFOLDER}/ge25519_dbl_p1p1.s"
+    "${LIBFOLDER}/ge25519_double.c"
+    "${LIBFOLDER}/ge25519_nielsadd_p1p1.s"
+    "${LIBFOLDER}/ge25519_nielsadd2.s"
+    "${LIBFOLDER}/ge25519_pack.c"
+    "${LIBFOLDER}/ge25519_p1p1_to_p2.s"
+    "${LIBFOLDER}/ge25519_p1p1_to_p3.s"
+    "${LIBFOLDER}/ge25519_pnielsadd_p1p1.s"
+    "${LIBFOLDER}/ge25519_scalarmult_base.c"
+    "${LIBFOLDER}/ge25519_unpackneg.c"
+    "${LIBFOLDER}/sc25519_from32bytes.c"
+    "${LIBFOLDER}/sc25519_window4.c"
+    ${AMD64_PERF_SOURCES})
+  target_include_directories("monero-crypto-${LIBNAME}" PRIVATE ${LIBFOLDER})
+endfunction (add_amd64_library)
+
+add_amd64_library(
+  "amd64-64-24k"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-64-24k"
+  SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-64-24k/fe25519_add.s"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-64-24k/fe25519_sub.s")
+
+add_amd64_library(
+  "amd64-51-30k"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-51-30k"
+  SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-51-30k/fe25519_add.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-51-30k/fe25519_nsquare.s"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-51-30k/fe25519_sub.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../crypto_sign/ed25519/amd64-51-30k/ge25519_p1p1_to_pniels.s")

--- a/src/amd64/amd64-51-30k-choose_tp.s
+++ b/src/amd64/amd64-51-30k-choose_tp.s
@@ -1,0 +1,2189 @@
+
+# qhasm: int64 tp
+
+# qhasm: int64 pos
+
+# qhasm: int64 b
+
+# qhasm: int64 basep
+
+# qhasm: input tp
+
+# qhasm: input pos
+
+# qhasm: input b
+
+# qhasm: input basep
+
+# qhasm: int64 mask
+
+# qhasm: int64 u
+
+# qhasm: int64 tysubx0
+
+# qhasm: int64 tysubx1
+
+# qhasm: int64 tysubx2
+
+# qhasm: int64 tysubx3
+
+# qhasm: int64 tysubx4
+
+# qhasm: int64 txaddy0
+
+# qhasm: int64 txaddy1
+
+# qhasm: int64 txaddy2
+
+# qhasm: int64 txaddy3
+
+# qhasm: int64 txaddy4
+
+# qhasm: int64 tt2d0
+
+# qhasm: int64 tt2d1
+
+# qhasm: int64 tt2d2
+
+# qhasm: int64 tt2d3
+
+# qhasm: int64 tt2d4
+
+# qhasm: int64 tt0
+
+# qhasm: int64 tt1
+
+# qhasm: int64 tt2
+
+# qhasm: int64 tt3
+
+# qhasm: int64 tt4
+
+# qhasm: int64 t
+
+# qhasm: stack64 tp_stack
+
+# qhasm:   int64 caller1
+
+# qhasm:   int64 caller2
+
+# qhasm:   int64 caller3
+
+# qhasm:   int64 caller4
+
+# qhasm:   int64 caller5
+
+# qhasm:   int64 caller6
+
+# qhasm:   int64 caller7
+
+# qhasm:   caller caller1
+
+# qhasm:   caller caller2
+
+# qhasm:   caller caller3
+
+# qhasm:   caller caller4
+
+# qhasm:   caller caller5
+
+# qhasm:   caller caller6
+
+# qhasm:   caller caller7
+
+# qhasm:   stack64 caller1_stack
+
+# qhasm:   stack64 caller2_stack
+
+# qhasm:   stack64 caller3_stack
+
+# qhasm:   stack64 caller4_stack
+
+# qhasm:   stack64 caller5_stack
+
+# qhasm:   stack64 caller6_stack
+
+# qhasm:   stack64 caller7_stack
+
+# qhasm: enter crypto_sign_ed25519_amd64_51_30k_batch_choose_t
+.text
+.p2align 5
+.globl _crypto_sign_ed25519_amd64_51_30k_batch_choose_tp
+.globl crypto_sign_ed25519_amd64_51_30k_batch_choose_tp
+_crypto_sign_ed25519_amd64_51_30k_batch_choose_tp:
+crypto_sign_ed25519_amd64_51_30k_batch_choose_tp:
+mov %rsp,%r11
+and $31,%r11
+add $64,%r11
+sub %r11,%rsp
+
+# qhasm:   caller1_stack = caller1
+# asm 1: movq <caller1=int64#9,>caller1_stack=stack64#1
+# asm 2: movq <caller1=%r11,>caller1_stack=0(%rsp)
+movq %r11,0(%rsp)
+
+# qhasm:   caller2_stack = caller2
+# asm 1: movq <caller2=int64#10,>caller2_stack=stack64#2
+# asm 2: movq <caller2=%r12,>caller2_stack=8(%rsp)
+movq %r12,8(%rsp)
+
+# qhasm:   caller3_stack = caller3
+# asm 1: movq <caller3=int64#11,>caller3_stack=stack64#3
+# asm 2: movq <caller3=%r13,>caller3_stack=16(%rsp)
+movq %r13,16(%rsp)
+
+# qhasm:   caller4_stack = caller4
+# asm 1: movq <caller4=int64#12,>caller4_stack=stack64#4
+# asm 2: movq <caller4=%r14,>caller4_stack=24(%rsp)
+movq %r14,24(%rsp)
+
+# qhasm:   caller5_stack = caller5
+# asm 1: movq <caller5=int64#13,>caller5_stack=stack64#5
+# asm 2: movq <caller5=%r15,>caller5_stack=32(%rsp)
+movq %r15,32(%rsp)
+
+# qhasm:   caller6_stack = caller6
+# asm 1: movq <caller6=int64#14,>caller6_stack=stack64#6
+# asm 2: movq <caller6=%rbx,>caller6_stack=40(%rsp)
+movq %rbx,40(%rsp)
+
+# qhasm:   caller7_stack = caller7
+# asm 1: movq <caller7=int64#15,>caller7_stack=stack64#7
+# asm 2: movq <caller7=%rbp,>caller7_stack=48(%rsp)
+movq %rbp,48(%rsp)
+
+# qhasm: tp_stack = tp
+# asm 1: movq <tp=int64#1,>tp_stack=stack64#8
+# asm 2: movq <tp=%rdi,>tp_stack=56(%rsp)
+movq %rdi,56(%rsp)
+
+# qhasm: pos *= 960
+# asm 1: imulq  $960,<pos=int64#2,>pos=int64#1
+# asm 2: imulq  $960,<pos=%rsi,>pos=%rdi
+imulq  $960,%rsi,%rdi
+
+# qhasm: mask = b
+# asm 1: mov  <b=int64#3,>mask=int64#2
+# asm 2: mov  <b=%rdx,>mask=%rsi
+mov  %rdx,%rsi
+
+# qhasm: (int64) mask >>= 7
+# asm 1: sar  $7,<mask=int64#2
+# asm 2: sar  $7,<mask=%rsi
+sar  $7,%rsi
+
+# qhasm: u = b
+# asm 1: mov  <b=int64#3,>u=int64#5
+# asm 2: mov  <b=%rdx,>u=%r8
+mov  %rdx,%r8
+
+# qhasm: u += mask
+# asm 1: add  <mask=int64#2,<u=int64#5
+# asm 2: add  <mask=%rsi,<u=%r8
+add  %rsi,%r8
+
+# qhasm: u ^= mask
+# asm 1: xor  <mask=int64#2,<u=int64#5
+# asm 2: xor  <mask=%rsi,<u=%r8
+xor  %rsi,%r8
+
+# qhasm: tysubx0 = 1
+# asm 1: mov  $1,>tysubx0=int64#2
+# asm 2: mov  $1,>tysubx0=%rsi
+mov  $1,%rsi
+
+# qhasm: tysubx1 = 0
+# asm 1: mov  $0,>tysubx1=int64#6
+# asm 2: mov  $0,>tysubx1=%r9
+mov  $0,%r9
+
+# qhasm: tysubx2 = 0
+# asm 1: mov  $0,>tysubx2=int64#7
+# asm 2: mov  $0,>tysubx2=%rax
+mov  $0,%rax
+
+# qhasm: tysubx3 = 0
+# asm 1: mov  $0,>tysubx3=int64#8
+# asm 2: mov  $0,>tysubx3=%r10
+mov  $0,%r10
+
+# qhasm: tysubx4 = 0
+# asm 1: mov  $0,>tysubx4=int64#9
+# asm 2: mov  $0,>tysubx4=%r11
+mov  $0,%r11
+
+# qhasm: txaddy0 = 1
+# asm 1: mov  $1,>txaddy0=int64#10
+# asm 2: mov  $1,>txaddy0=%r12
+mov  $1,%r12
+
+# qhasm: txaddy1 = 0
+# asm 1: mov  $0,>txaddy1=int64#11
+# asm 2: mov  $0,>txaddy1=%r13
+mov  $0,%r13
+
+# qhasm: txaddy2 = 0
+# asm 1: mov  $0,>txaddy2=int64#12
+# asm 2: mov  $0,>txaddy2=%r14
+mov  $0,%r14
+
+# qhasm: txaddy3 = 0
+# asm 1: mov  $0,>txaddy3=int64#13
+# asm 2: mov  $0,>txaddy3=%r15
+mov  $0,%r15
+
+# qhasm: txaddy4 = 0
+# asm 1: mov  $0,>txaddy4=int64#14
+# asm 2: mov  $0,>txaddy4=%rbx
+mov  $0,%rbx
+
+# qhasm: =? u - 1
+# asm 1: cmp  $1,<u=int64#5
+# asm 2: cmp  $1,<u=%r8
+cmp  $1,%r8
+
+# qhasm: t = *(uint64 *)(basep + 0 + pos)
+# asm 1: movq   0(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   0(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   0(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 8 + pos)
+# asm 1: movq   8(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   8(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   8(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 16 + pos)
+# asm 1: movq   16(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   16(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   16(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 24 + pos)
+# asm 1: movq   24(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   24(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   24(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 32 + pos)
+# asm 1: movq   32(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   32(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   32(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 40 + pos)
+# asm 1: movq   40(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   40(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   40(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 48 + pos)
+# asm 1: movq   48(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   48(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   48(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 56 + pos)
+# asm 1: movq   56(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   56(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   56(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 64 + pos)
+# asm 1: movq   64(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   64(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   64(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 72 + pos)
+# asm 1: movq   72(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   72(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   72(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: =? u - 2
+# asm 1: cmp  $2,<u=int64#5
+# asm 2: cmp  $2,<u=%r8
+cmp  $2,%r8
+
+# qhasm: t = *(uint64 *)(basep + 160 + pos)
+# asm 1: movq   160(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   160(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   160(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 168 + pos)
+# asm 1: movq   168(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   168(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   168(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 176 + pos)
+# asm 1: movq   176(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   176(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   176(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 184 + pos)
+# asm 1: movq   184(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   184(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   184(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 192 + pos)
+# asm 1: movq   192(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   192(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   192(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 200 + pos)
+# asm 1: movq   200(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   200(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   200(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 208 + pos)
+# asm 1: movq   208(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   208(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   208(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 216 + pos)
+# asm 1: movq   216(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   216(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   216(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 224 + pos)
+# asm 1: movq   184(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   184(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   224(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 232 + pos)
+# asm 1: movq   232(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   232(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   232(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: =? u - 3
+# asm 1: cmp  $3,<u=int64#5
+# asm 2: cmp  $3,<u=%r8
+cmp  $3,%r8
+
+# qhasm: t = *(uint64 *)(basep + 320 + pos)
+# asm 1: movq   320(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   320(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   320(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 328 + pos)
+# asm 1: movq   328(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   328(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   328(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 336 + pos)
+# asm 1: movq   336(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   336(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   336(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 344 + pos)
+# asm 1: movq   344(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   344(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   344(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 352 + pos)
+# asm 1: movq   272(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   272(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   352(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 360 + pos)
+# asm 1: movq   360(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   360(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   360(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 368 + pos)
+# asm 1: movq   368(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   368(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   368(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 376 + pos)
+# asm 1: movq   376(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   376(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   376(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 384 + pos)
+# asm 1: movq   384(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   384(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   384(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 392 + pos)
+# asm 1: movq   392(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   392(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   392(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: =? u - 4
+# asm 1: cmp  $4,<u=int64#5
+# asm 2: cmp  $4,<u=%r8
+cmp  $4,%r8
+
+# qhasm: t = *(uint64 *)(basep + 480 + pos)
+# asm 1: movq   480(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   480(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   480(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 488 + pos)
+# asm 1: movq   488(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   488(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   488(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 496 + pos)
+# asm 1: movq   496(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   496(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   496(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 504 + pos)
+# asm 1: movq   384(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   384(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   504(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 512 + pos)
+# asm 1: movq   512(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   512(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   512(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 400 + pos)
+# asm 1: movq   400(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   400(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   520(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 528 + pos)
+# asm 1: movq   528(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   528(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   528(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 536 + pos)
+# asm 1: movq   536(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   536(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   536(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 544 + pos)
+# asm 1: movq   424(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   424(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   544(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 552 + pos)
+# asm 1: movq   552(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   552(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   552(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: =? u - 5
+# asm 1: cmp  $5,<u=int64#5
+# asm 2: cmp  $5,<u=%r8
+cmp  $5,%r8
+
+# qhasm: t = *(uint64 *)(basep + 640 + pos)
+# asm 1: movq   640(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   640(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   640(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 648 + pos)
+# asm 1: movq   648(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   648(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   648(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 656 + pos)
+# asm 1: movq   656(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   656(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   656(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 664 + pos)
+# asm 1: movq   664(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   664(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   664(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 672 + pos)
+# asm 1: movq   512(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   512(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   672(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 680 + pos)
+# asm 1: movq   680(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   680(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   680(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 688 + pos)
+# asm 1: movq   688(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   688(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   688(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 696 + pos)
+# asm 1: movq   696(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   696(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   696(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 704 + pos)
+# asm 1: movq   704(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   704(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   704(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 712 + pos)
+# asm 1: movq   712(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   712(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   712(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: =? u - 6
+# asm 1: cmp  $6,<u=int64#5
+# asm 2: cmp  $6,<u=%r8
+cmp  $6,%r8
+
+# qhasm: t = *(uint64 *)(basep + 800 + pos)
+# asm 1: movq   800(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   800(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   800(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 808 + pos)
+# asm 1: movq   808(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   808(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   808(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 816 + pos)
+# asm 1: movq   816(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   816(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   816(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 824 + pos)
+# asm 1: movq   824(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   824(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   824(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 832 + pos)
+# asm 1: movq   832(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   832(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   832(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 640 + pos)
+# asm 1: movq   640(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   640(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   840(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 848 + pos)
+# asm 1: movq   848(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   848(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   848(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 856 + pos)
+# asm 1: movq   856(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   856(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   856(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 864 + pos)
+# asm 1: movq   864(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   864(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   864(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 872 + pos)
+# asm 1: movq   872(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   872(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   872(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: =? u - 7
+# asm 1: cmp  $7,<u=int64#5
+# asm 2: cmp  $7,<u=%r8
+cmp  $7,%r8
+
+# qhasm: t = *(uint64 *)(basep + 960 + pos)
+# asm 1: movq   960(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   960(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   960(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 968 + pos)
+# asm 1: movq   968(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   968(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   968(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 976 + pos)
+# asm 1: movq   976(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   976(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   976(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 984 + pos)
+# asm 1: movq   984(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   984(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   984(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 992 + pos)
+# asm 1: movq   992(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   992(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   992(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 1000 + pos)
+# asm 1: movq   1000(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1000(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1000(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 1008 + pos)
+# asm 1: movq   1008(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1008(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1008(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 1016 + pos)
+# asm 1: movq   1016(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1016(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1016(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 1024 + pos)
+# asm 1: movq   1024(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1024(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1024(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 1032 + pos)
+# asm 1: movq   1032(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1032(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1032(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: =? u - 8
+# asm 1: cmp  $8,<u=int64#5
+# asm 2: cmp  $8,<u=%r8
+cmp  $8,%r8
+
+# qhasm: t = *(uint64 *)(basep + 1120 + pos)
+# asm 1: movq   1120(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1120(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1120(%rcx,%rdi),%rbp
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#15,<tysubx0=int64#2
+# asm 2: cmove <t=%rbp,<tysubx0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 1128 + pos)
+# asm 1: movq   1128(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1128(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1128(%rcx,%rdi),%rbp
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#15,<tysubx1=int64#6
+# asm 2: cmove <t=%rbp,<tysubx1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 1136 + pos)
+# asm 1: movq   1136(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1136(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1136(%rcx,%rdi),%rbp
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#15,<tysubx2=int64#7
+# asm 2: cmove <t=%rbp,<tysubx2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 1144 + pos)
+# asm 1: movq   1144(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1144(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1144(%rcx,%rdi),%rbp
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#15,<tysubx3=int64#8
+# asm 2: cmove <t=%rbp,<tysubx3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 1152 + pos)
+# asm 1: movq   1152(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1152(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1152(%rcx,%rdi),%rbp
+
+# qhasm: tysubx4 = t if =
+# asm 1: cmove <t=int64#15,<tysubx4=int64#9
+# asm 2: cmove <t=%rbp,<tysubx4=%r11
+cmove %rbp,%r11
+
+# qhasm: t = *(uint64 *)(basep + 1160 + pos)
+# asm 1: movq   1160(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1160(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1160(%rcx,%rdi),%rbp
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#15,<txaddy0=int64#10
+# asm 2: cmove <t=%rbp,<txaddy0=%r12
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 1168 + pos)
+# asm 1: movq   1168(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1168(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1168(%rcx,%rdi),%rbp
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#15,<txaddy1=int64#11
+# asm 2: cmove <t=%rbp,<txaddy1=%r13
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 1176 + pos)
+# asm 1: movq   1176(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1176(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1176(%rcx,%rdi),%rbp
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#15,<txaddy2=int64#12
+# asm 2: cmove <t=%rbp,<txaddy2=%r14
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 1184 + pos)
+# asm 1: movq   1184(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1184(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1184(%rcx,%rdi),%rbp
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#15,<txaddy3=int64#13
+# asm 2: cmove <t=%rbp,<txaddy3=%r15
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 1192 + pos)
+# asm 1: movq   1192(<basep=int64#4,<pos=int64#1),>t=int64#15
+# asm 2: movq   1192(<basep=%rcx,<pos=%rdi),>t=%rbp
+movq   1192(%rcx,%rdi),%rbp
+
+# qhasm: txaddy4 = t if =
+# asm 1: cmove <t=int64#15,<txaddy4=int64#14
+# asm 2: cmove <t=%rbp,<txaddy4=%rbx
+cmove %rbp,%rbx
+
+# qhasm: signed<? b - 0
+# asm 1: cmp  $0,<b=int64#3
+# asm 2: cmp  $0,<b=%rdx
+cmp  $0,%rdx
+
+# qhasm: t = tysubx0
+# asm 1: mov  <tysubx0=int64#2,>t=int64#15
+# asm 2: mov  <tysubx0=%rsi,>t=%rbp
+mov  %rsi,%rbp
+
+# qhasm: tysubx0 = txaddy0 if signed<
+# asm 1: cmovl <txaddy0=int64#10,<tysubx0=int64#2
+# asm 2: cmovl <txaddy0=%r12,<tysubx0=%rsi
+cmovl %r12,%rsi
+
+# qhasm: txaddy0 = t if signed<
+# asm 1: cmovl <t=int64#15,<txaddy0=int64#10
+# asm 2: cmovl <t=%rbp,<txaddy0=%r12
+cmovl %rbp,%r12
+
+# qhasm: t = tysubx1
+# asm 1: mov  <tysubx1=int64#6,>t=int64#15
+# asm 2: mov  <tysubx1=%r9,>t=%rbp
+mov  %r9,%rbp
+
+# qhasm: tysubx1 = txaddy1 if signed<
+# asm 1: cmovl <txaddy1=int64#11,<tysubx1=int64#6
+# asm 2: cmovl <txaddy1=%r13,<tysubx1=%r9
+cmovl %r13,%r9
+
+# qhasm: txaddy1 = t if signed<
+# asm 1: cmovl <t=int64#15,<txaddy1=int64#11
+# asm 2: cmovl <t=%rbp,<txaddy1=%r13
+cmovl %rbp,%r13
+
+# qhasm: t = tysubx2
+# asm 1: mov  <tysubx2=int64#7,>t=int64#15
+# asm 2: mov  <tysubx2=%rax,>t=%rbp
+mov  %rax,%rbp
+
+# qhasm: tysubx2 = txaddy2 if signed<
+# asm 1: cmovl <txaddy2=int64#12,<tysubx2=int64#7
+# asm 2: cmovl <txaddy2=%r14,<tysubx2=%rax
+cmovl %r14,%rax
+
+# qhasm: txaddy2 = t if signed<
+# asm 1: cmovl <t=int64#15,<txaddy2=int64#12
+# asm 2: cmovl <t=%rbp,<txaddy2=%r14
+cmovl %rbp,%r14
+
+# qhasm: t = tysubx3
+# asm 1: mov  <tysubx3=int64#8,>t=int64#15
+# asm 2: mov  <tysubx3=%r10,>t=%rbp
+mov  %r10,%rbp
+
+# qhasm: tysubx3 = txaddy3 if signed<
+# asm 1: cmovl <txaddy3=int64#13,<tysubx3=int64#8
+# asm 2: cmovl <txaddy3=%r15,<tysubx3=%r10
+cmovl %r15,%r10
+
+# qhasm: txaddy3 = t if signed<
+# asm 1: cmovl <t=int64#15,<txaddy3=int64#13
+# asm 2: cmovl <t=%rbp,<txaddy3=%r15
+cmovl %rbp,%r15
+
+# qhasm: t = tysubx4
+# asm 1: mov  <tysubx4=int64#9,>t=int64#15
+# asm 2: mov  <tysubx4=%r11,>t=%rbp
+mov  %r11,%rbp
+
+# qhasm: tysubx4 = txaddy4 if signed<
+# asm 1: cmovl <txaddy4=int64#14,<tysubx4=int64#9
+# asm 2: cmovl <txaddy4=%rbx,<tysubx4=%r11
+cmovl %rbx,%r11
+
+# qhasm: txaddy4 = t if signed<
+# asm 1: cmovl <t=int64#15,<txaddy4=int64#14
+# asm 2: cmovl <t=%rbp,<txaddy4=%rbx
+cmovl %rbp,%rbx
+
+# qhasm: tp = tp_stack
+# asm 1: movq <tp_stack=stack64#8,>tp=int64#15
+# asm 2: movq <tp_stack=56(%rsp),>tp=%rbp
+movq 56(%rsp),%rbp
+
+# qhasm: *(uint64 *)(tp + 0) = tysubx0
+# asm 1: movq   <tysubx0=int64#2,0(<tp=int64#15)
+# asm 2: movq   <tysubx0=%rsi,0(<tp=%rbp)
+movq   %rsi,0(%rbp)
+
+# qhasm: *(uint64 *)(tp + 8) = tysubx1
+# asm 1: movq   <tysubx1=int64#6,8(<tp=int64#15)
+# asm 2: movq   <tysubx1=%r9,8(<tp=%rbp)
+movq   %r9,8(%rbp)
+
+# qhasm: *(uint64 *)(tp + 16) = tysubx2
+# asm 1: movq   <tysubx2=int64#7,16(<tp=int64#15)
+# asm 2: movq   <tysubx2=%rax,16(<tp=%rbp)
+movq   %rax,16(%rbp)
+
+# qhasm: *(uint64 *)(tp + 24) = tysubx3
+# asm 1: movq   <tysubx3=int64#8,24(<tp=int64#15)
+# asm 2: movq   <tysubx3=%r10,24(<tp=%rbp)
+movq   %r10,24(%rbp)
+
+# qhasm: *(uint64 *)(tp + 32) = tysubx4
+# asm 1: movq   <tysubx4=int64#9,32(<tp=int64#15)
+# asm 2: movq   <tysubx4=%r11,32(<tp=%rbp)
+movq   %r11,32(%rbp)
+
+# qhasm: *(uint64 *)(tp + 40) = txaddy0
+# asm 1: movq   <txaddy0=int64#10,40(<tp=int64#15)
+# asm 2: movq   <txaddy0=%r12,40(<tp=%rbp)
+movq   %r12,40(%rbp)
+
+# qhasm: *(uint64 *)(tp + 48) = txaddy1
+# asm 1: movq   <txaddy1=int64#11,48(<tp=int64#15)
+# asm 2: movq   <txaddy1=%r13,48(<tp=%rbp)
+movq   %r13,48(%rbp)
+
+# qhasm: *(uint64 *)(tp + 56) = txaddy2
+# asm 1: movq   <txaddy2=int64#12,56(<tp=int64#15)
+# asm 2: movq   <txaddy2=%r14,56(<tp=%rbp)
+movq   %r14,56(%rbp)
+
+# qhasm: *(uint64 *)(tp + 64) = txaddy3
+# asm 1: movq   <txaddy3=int64#13,64(<tp=int64#15)
+# asm 2: movq   <txaddy3=%r15,64(<tp=%rbp)
+movq   %r15,64(%rbp)
+
+# qhasm: *(uint64 *)(tp + 72) = txaddy4
+# asm 1: movq   <txaddy4=int64#14,72(<tp=int64#15)
+# asm 2: movq   <txaddy4=%rbx,72(<tp=%rbp)
+movq   %rbx,72(%rbp)
+
+# qhasm: tz0 = 1
+mov  $1,%r12
+
+# qhasm: tz1 = 0
+mov  $0,%r13
+
+# qhasm: tz2 = 0
+mov  $0,%r14
+
+# qhasm: tz3 = 0
+mov  $0,%r15
+
+# qhasm: tz4 = 0
+mov  $0,%rbx
+
+# qhasm: tt2d0 = 0
+# asm 1: mov  $0,>tt2d0=int64#2
+# asm 2: mov  $0,>tt2d0=%rsi
+mov  $0,%rsi
+
+# qhasm: tt2d1 = 0
+# asm 1: mov  $0,>tt2d1=int64#6
+# asm 2: mov  $0,>tt2d1=%r9
+mov  $0,%r9
+
+# qhasm: tt2d2 = 0
+# asm 1: mov  $0,>tt2d2=int64#7
+# asm 2: mov  $0,>tt2d2=%rax
+mov  $0,%rax
+
+# qhasm: tt2d3 = 0
+# asm 1: mov  $0,>tt2d3=int64#8
+# asm 2: mov  $0,>tt2d3=%r10
+mov  $0,%r10
+
+# qhasm: tt2d4 = 0
+# asm 1: mov  $0,>tt2d4=int64#9
+# asm 2: mov  $0,>tt2d4=%r11
+mov  $0,%r11
+
+# qhasm: =? u - 1
+# asm 1: cmp  $1,<u=int64#5
+# asm 2: cmp  $1,<u=%r8
+cmp  $1,%r8
+
+# qhasm: t = *(uint64 *)(basep + 80 + pos)
+# asm 1: movq   80(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   80(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   80(%rcx,%rdi),%rbp
+
+# qhasm: tz0 = t if =
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 88 + pos)
+# asm 1: movq   80(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   80(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   88(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 96 + pos)
+# asm 1: movq   96(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   96(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   96(%rcx,%rdi),%rbp
+
+# qhasm: tz2 = t if =
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 104 + pos)
+# asm 1: movq   104(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   104(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   104(%rcx,%rdi),%rbp
+
+# qhasm: tz3 = t if =
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 112 + pos)
+# asm 1: movq   112(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   112(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   112(%rcx,%rdi),%rbp
+
+# qhasm: tz4 = t if =
+cmove %rbp,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 120 + pos)
+# asm 1: movq   120(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   120(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   120(%rcx,%rdi),%rbp
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#10,<tt2d0=int64#2
+# asm 2: cmove <t=%r12,<tt2d0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 128 + pos)
+# asm 1: movq   128(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   128(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   128(%rcx,%rdi),%rbp
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#10,<tt2d1=int64#6
+# asm 2: cmove <t=%r12,<tt2d1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 136 + pos)
+# asm 1: movq   136(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   136(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   136(%rcx,%rdi),%rbp
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#10,<tt2d2=int64#7
+# asm 2: cmove <t=%r12,<tt2d2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 144 + pos)
+# asm 1: movq   144(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   144(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   144(%rcx,%rdi),%rbp
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#10,<tt2d3=int64#8
+# asm 2: cmove <t=%r12,<tt2d3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 152 + pos)
+# asm 1: movq   152(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   152(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   152(%rcx,%rdi),%rbp
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#10,<tt2d4=int64#9
+# asm 2: cmove <t=%r12,<tt2d4=%r11
+cmove %rbp,%r11
+
+# qhasm: =? u - 2
+# asm 1: cmp  $2,<u=int64#5
+# asm 2: cmp  $2,<u=%r8
+cmp  $2,%r8
+
+# qhasm: t = *(uint64 *)(basep + 240 + pos)
+# asm 1: movq   240(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   240(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   240(%rcx,%rdi),%rbp
+
+# qhasm: tz0 = t if =
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 248 + pos)
+# asm 1: movq   248(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   248(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   248(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 256 + pos)
+# asm 1: movq   256(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   256(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   256(%rcx,%rdi),%rbp
+
+# qhasm: tz2 = t if =
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 264 + pos)
+# asm 1: movq   264(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   264(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   264(%rcx,%rdi),%rbp
+
+# qhasm: tz3 = t if =
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 272 + pos)
+# asm 1: movq   272(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   272(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   272(%rcx,%rdi),%rbp
+
+# qhasm: tz4 = t if =
+cmove %rbp,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 280 + pos)
+# asm 1: movq   280(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   280(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   280(%rcx,%rdi),%rbp
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#10,<tt2d0=int64#2
+# asm 2: cmove <t=%r12,<tt2d0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 288 + pos)
+# asm 1: movq   288(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   288(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   288(%rcx,%rdi),%rbp
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#10,<tt2d1=int64#6
+# asm 2: cmove <t=%r12,<tt2d1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 296 + pos)
+# asm 1: movq   296(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   296(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   296(%rcx,%rdi),%rbp
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#10,<tt2d2=int64#7
+# asm 2: cmove <t=%r12,<tt2d2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 304 + pos)
+# asm 1: movq   304(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   304(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   304(%rcx,%rdi),%rbp
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#10,<tt2d3=int64#8
+# asm 2: cmove <t=%r12,<tt2d3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 312 + pos)
+# asm 1: movq   312(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   312(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   312(%rcx,%rdi),%rbp
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#10,<tt2d4=int64#9
+# asm 2: cmove <t=%r12,<tt2d4=%r11
+cmove %rbp,%r11
+
+# qhasm: =? u - 3
+# asm 1: cmp  $3,<u=int64#5
+# asm 2: cmp  $3,<u=%r8
+cmp  $3,%r8
+
+# qhasm: t = *(uint64 *)(basep + 400 + pos)
+# asm 1: movq   400(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   400(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   400(%rcx,%rdi),%rbp
+
+# qhasm: tz0 = t if =
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 408 + pos)
+# asm 1: movq   408(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   408(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   408(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 416 + pos)
+# asm 1: movq   416(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   416(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   416(%rcx,%rdi),%rbp
+
+# qhasm: tz2 = t if =
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 424 + pos)
+# asm 1: movq   424(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   424(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   424(%rcx,%rdi),%rbp
+
+# qhasm: tz3 = t if =
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 432 + pos)
+# asm 1: movq   432(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   432(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   432(%rcx,%rdi),%rbp
+
+# qhasm: tz4 = t if =
+cmove %rbp,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 440 + pos)
+# asm 1: movq   440(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   440(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   440(%rcx,%rdi),%rbp
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#10,<tt2d0=int64#2
+# asm 2: cmove <t=%r12,<tt2d0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 448 + pos)
+# asm 1: movq   448(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   448(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   448(%rcx,%rdi),%rbp
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#10,<tt2d1=int64#6
+# asm 2: cmove <t=%r12,<tt2d1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 336 + pos)
+# asm 1: movq   336(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   336(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   456(%rcx,%rdi),%rbp
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#10,<tt2d2=int64#7
+# asm 2: cmove <t=%r12,<tt2d2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 344 + pos)
+# asm 1: movq   344(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   344(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   464(%rcx,%rdi),%rbp
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#10,<tt2d3=int64#8
+# asm 2: cmove <t=%r12,<tt2d3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 472 + pos)
+# asm 1: movq   472(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   472(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   472(%rcx,%rdi),%rbp
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#10,<tt2d4=int64#9
+# asm 2: cmove <t=%r12,<tt2d4=%r11
+cmove %rbp,%r11
+
+# qhasm: =? u - 4
+# asm 1: cmp  $4,<u=int64#5
+# asm 2: cmp  $4,<u=%r8
+cmp  $4,%r8
+
+# qhasm: t = *(uint64 *)(basep + 560 + pos)
+# asm 1: movq   560(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   560(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   560(%rcx,%rdi),%rbp
+
+# qhasm: tz0 = t if =
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 568 + pos)
+# asm 1: movq   568(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   568(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   568(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 576 + pos)
+# asm 1: movq   576(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   576(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   576(%rcx,%rdi),%rbp
+
+# qhasm: tz2 = t if =
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 584 + pos)
+# asm 1: movq   584(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   584(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   584(%rcx,%rdi),%rbp
+
+# qhasm: tz3 = t if =
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 592 + pos)
+# asm 1: movq   592(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   592(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   592(%rcx,%rdi),%rbp
+
+# qhasm: tz4 = t if =
+cmove %rbp,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 600 + pos)
+# asm 1: movq   600(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   600(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   600(%rcx,%rdi),%rbp
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#10,<tt2d0=int64#2
+# asm 2: cmove <t=%r12,<tt2d0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 608 + pos)
+# asm 1: movq   608(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   608(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   608(%rcx,%rdi),%rbp
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#10,<tt2d1=int64#6
+# asm 2: cmove <t=%r12,<tt2d1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 616 + pos)
+# asm 1: movq   616(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   616(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   616(%rcx,%rdi),%rbp
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#10,<tt2d2=int64#7
+# asm 2: cmove <t=%r12,<tt2d2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 624 + pos)
+# asm 1: movq   624(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   624(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   624(%rcx,%rdi),%rbp
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#10,<tt2d3=int64#8
+# asm 2: cmove <t=%r12,<tt2d3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 632 + pos)
+# asm 1: movq   632(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   632(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   632(%rcx,%rdi),%rbp
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#10,<tt2d4=int64#9
+# asm 2: cmove <t=%r12,<tt2d4=%r11
+cmove %rbp,%r11
+
+# qhasm: =? u - 5
+# asm 1: cmp  $5,<u=int64#5
+# asm 2: cmp  $5,<u=%r8
+cmp  $5,%r8
+
+# qhasm: t = *(uint64 *)(basep + 720 + pos)
+# asm 1: movq   720(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   720(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   720(%rcx,%rdi),%rbp
+
+# qhasm: tz0 = t if =
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 728 + pos)
+# asm 1: movq   728(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   728(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   728(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 736 + pos)
+# asm 1: movq   736(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   736(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   736(%rcx,%rdi),%rbp
+
+# qhasm: tz2 = t if =
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 744 + pos)
+# asm 1: movq   744(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   744(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   744(%rcx,%rdi),%rbp
+
+# qhasm: tz3 = t if =
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 752 + pos)
+# asm 1: movq   752(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   752(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   752(%rcx,%rdi),%rbp
+
+# qhasm: tz4 = t if =
+cmove %rbp,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 760 + pos)
+# asm 1: movq   760(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   760(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   760(%rcx,%rdi),%rbp
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#10,<tt2d0=int64#2
+# asm 2: cmove <t=%r12,<tt2d0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 768 + pos)
+# asm 1: movq   768(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   768(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   768(%rcx,%rdi),%rbp
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#10,<tt2d1=int64#6
+# asm 2: cmove <t=%r12,<tt2d1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 776 + pos)
+# asm 1: movq   776(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   776(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   776(%rcx,%rdi),%rbp
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#10,<tt2d2=int64#7
+# asm 2: cmove <t=%r12,<tt2d2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 784 + pos)
+# asm 1: movq   784(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   784(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   784(%rcx,%rdi),%rbp
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#10,<tt2d3=int64#8
+# asm 2: cmove <t=%r12,<tt2d3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 792 + pos)
+# asm 1: movq   792(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   792(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   792(%rcx,%rdi),%rbp
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#10,<tt2d4=int64#9
+# asm 2: cmove <t=%r12,<tt2d4=%r11
+cmove %rbp,%r11
+
+# qhasm: =? u - 6
+# asm 1: cmp  $6,<u=int64#5
+# asm 2: cmp  $6,<u=%r8
+cmp  $6,%r8
+
+# qhasm: t = *(uint64 *)(basep + 880 + pos)
+# asm 1: movq   880(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   880(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   880(%rcx,%rdi),%rbp
+
+# qhasm: tz0 = t if =
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 888 + pos)
+# asm 1: movq   888(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   888(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   888(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 896 + pos)
+# asm 1: movq   896(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   896(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   896(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 904 + pos)
+# asm 1: movq   904(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   904(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   904(%rcx,%rdi),%rbp
+
+# qhasm: tz2 = t if =
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 912 + pos)
+# asm 1: movq   912(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   912(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   912(%rcx,%rdi),%rbp
+
+# qhasm: tz3 = t if =
+cmove %rbp,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 920 + pos)
+# asm 1: movq   920(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   920(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   920(%rcx,%rdi),%rbp
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#10,<tt2d0=int64#2
+# asm 2: cmove <t=%r12,<tt2d0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 928 + pos)
+# asm 1: movq   928(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   928(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   928(%rcx,%rdi),%rbp
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#10,<tt2d1=int64#6
+# asm 2: cmove <t=%r12,<tt2d1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 936 + pos)
+# asm 1: movq   936(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   936(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   936(%rcx,%rdi),%rbp
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#10,<tt2d2=int64#7
+# asm 2: cmove <t=%r12,<tt2d2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 944 + pos)
+# asm 1: movq   944(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   944(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   944(%rcx,%rdi),%rbp
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#10,<tt2d3=int64#8
+# asm 2: cmove <t=%r12,<tt2d3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 952 + pos)
+# asm 1: movq   952(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   952(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   952(%rcx,%rdi),%rbp
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#10,<tt2d4=int64#9
+# asm 2: cmove <t=%r12,<tt2d4=%r11
+cmove %rbp,%r11
+
+# qhasm: =? u - 7
+# asm 1: cmp  $7,<u=int64#5
+# asm 2: cmp  $7,<u=%r8
+cmp  $7,%r8
+
+# qhasm: t = *(uint64 *)(basep + 1040 + pos)
+# asm 1: movq   1040(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1040(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1040(%rcx,%rdi),%rbp
+
+# qhasm: tz0 = t if =
+cmove %rbp,%r12
+
+# qhasm: t = *(uint64 *)(basep + 1048 + pos)
+# asm 1: movq   1048(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1048(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1048(%rcx,%rdi),%rbp
+
+# qhasm: tz1 = t if =
+cmove %rbp,%r13
+
+# qhasm: t = *(uint64 *)(basep + 1056 + pos)
+# asm 1: movq   1056(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1056(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1056(%rcx,%rdi),%rbp
+
+# qhasm: tz2 = t if =
+cmove %rbp,%r14
+
+# qhasm: t = *(uint64 *)(basep + 1064 + pos)
+# asm 1: movq   1064(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1064(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1064(%rcx,%rdi),%rbp
+
+# qhasm: tz3 = t if =
+cmove %rbp,%r15
+
+# qhasm: t = *(uint64 *)(basep + 1072 + pos)
+# asm 1: movq   1072(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1072(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1072(%rcx,%rdi),%rbp
+
+# qhasm: tz4 = t if =
+cmove %rbp,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 1080 + pos)
+# asm 1: movq   1080(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1080(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1080(%rcx,%rdi),%rbp
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#10,<tt2d0=int64#2
+# asm 2: cmove <t=%r12,<tt2d0=%rsi
+cmove %rbp,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 1088 + pos)
+# asm 1: movq   1088(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1088(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1088(%rcx,%rdi),%rbp
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#10,<tt2d1=int64#6
+# asm 2: cmove <t=%r12,<tt2d1=%r9
+cmove %rbp,%r9
+
+# qhasm: t = *(uint64 *)(basep + 1096 + pos)
+# asm 1: movq   1096(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1096(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1096(%rcx,%rdi),%rbp
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#10,<tt2d2=int64#7
+# asm 2: cmove <t=%r12,<tt2d2=%rax
+cmove %rbp,%rax
+
+# qhasm: t = *(uint64 *)(basep + 1104 + pos)
+# asm 1: movq   1104(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1104(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1104(%rcx,%rdi),%rbp
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#10,<tt2d3=int64#8
+# asm 2: cmove <t=%r12,<tt2d3=%r10
+cmove %rbp,%r10
+
+# qhasm: t = *(uint64 *)(basep + 1112 + pos)
+# asm 1: movq   1112(<basep=int64#4,<pos=int64#1),>t=int64#10
+# asm 2: movq   1112(<basep=%rcx,<pos=%rdi),>t=%r12
+movq   1112(%rcx,%rdi),%rbp
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#10,<tt2d4=int64#9
+# asm 2: cmove <t=%r12,<tt2d4=%r11
+cmove %rbp,%r11
+
+# qhasm: =? u - 8
+# asm 1: cmp  $8,<u=int64#5
+# asm 2: cmp  $8,<u=%r8
+cmp  $8,%r8
+
+# qhasm: t = *(uint64 *)(basep + 1200 + pos)
+# asm 1: movq   1200(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1200(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1200(%rcx,%rdi),%r8
+
+# qhasm: tz0 = t if =
+cmove %r8,%r12
+
+# qhasm: t = *(uint64 *)(basep + 1208 + pos)
+# asm 1: movq   1208(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1208(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1208(%rcx,%rdi),%r8
+
+# qhasm: tz1 = t if =
+cmove %r8,%r13
+
+# qhasm: t = *(uint64 *)(basep + 1216 + pos)
+# asm 1: movq   1216(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1216(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1216(%rcx,%rdi),%r8
+
+# qhasm: tz2 = t if =
+cmove %r8,%r14
+
+# qhasm: t = *(uint64 *)(basep + 1224 + pos)
+# asm 1: movq   1224(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1224(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1224(%rcx,%rdi),%r8
+
+# qhasm: tz3 = t if =
+cmove %r8,%r15
+
+# qhasm: t = *(uint64 *)(basep + 1232 + pos)
+# asm 1: movq   1232(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1232(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1232(%rcx,%rdi),%r8
+
+# qhasm: tz4 = t if =
+cmove %r8,%rbx
+
+# qhasm: t = *(uint64 *)(basep + 1240 + pos)
+# asm 1: movq   1240(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1240(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1240(%rcx,%rdi),%r8
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#5,<tt2d0=int64#2
+# asm 2: cmove <t=%r8,<tt2d0=%rsi
+cmove %r8,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 1248 + pos)
+# asm 1: movq   1248(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1248(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1248(%rcx,%rdi),%r8
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#5,<tt2d1=int64#6
+# asm 2: cmove <t=%r8,<tt2d1=%r9
+cmove %r8,%r9
+
+# qhasm: t = *(uint64 *)(basep + 1256 + pos)
+# asm 1: movq   1256(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1256(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1256(%rcx,%rdi),%r8
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#5,<tt2d2=int64#7
+# asm 2: cmove <t=%r8,<tt2d2=%rax
+cmove %r8,%rax
+
+# qhasm: t = *(uint64 *)(basep + 1264 + pos)
+# asm 1: movq   1264(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1264(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1264(%rcx,%rdi),%r8
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#5,<tt2d3=int64#8
+# asm 2: cmove <t=%r8,<tt2d3=%r10
+cmove %r8,%r10
+
+# qhasm: t = *(uint64 *)(basep + 1272 + pos)
+# asm 1: movq   1272(<basep=int64#4,<pos=int64#1),>t=int64#1
+# asm 2: movq   1272(<basep=%rcx,<pos=%rdi),>t=%rdi
+movq   1272(%rcx,%rdi),%rdi
+
+# qhasm: tt2d4 = t if =
+# asm 1: cmove <t=int64#1,<tt2d4=int64#9
+# asm 2: cmove <t=%rdi,<tt2d4=%r11
+cmove %rdi,%r11
+
+# qhasm: tp = tp_stack
+# asm 1: movq <tp_stack=stack64#8,>tp=int64#15
+# asm 2: movq <tp_stack=56(%rsp),>tp=%rbp
+movq 56(%rsp),%rbp
+
+# qhasm: *(uint64 *)(tp + 80) = tz0
+# asm 1: movq   <tysubx0=int64#2,0(<tp=int64#15)
+# asm 2: movq   <tysubx0=%rsi,0(<tp=%rbp)
+movq   %r12,80(%rbp)
+
+# qhasm: *(uint64 *)(tp + 88) = tz0
+# asm 1: movq   <tysubx0=int64#2,0(<tp=int64#15)
+# asm 2: movq   <tysubx0=%rsi,0(<tp=%rbp)
+movq   %r13,88(%rbp)
+
+# qhasm: *(uint64 *)(tp + 96) = tz0
+# asm 1: movq   <tysubx0=int64#2,0(<tp=int64#15)
+# asm 2: movq   <tysubx0=%rsi,0(<tp=%rbp)
+movq   %r14,96(%rbp)
+
+# qhasm: *(uint64 *)(tp + 104) = tz0
+# asm 1: movq   <tysubx0=int64#2,0(<tp=int64#15)
+# asm 2: movq   <tysubx0=%rsi,0(<tp=%rbp)
+movq   %r15,104(%rbp)
+
+# qhasm: *(uint64 *)(tp + 112) = tz0
+# asm 1: movq   <tysubx0=int64#2,0(<tp=int64#15)
+# asm 2: movq   <tysubx0=%rsi,0(<tp=%rbp)
+movq   %rbx,112(%rbp)
+
+# qhasm: tt0 = *(uint64 *)&crypto_sign_ed25519_amd64_51_30k_batch_2P0
+# asm 1: movq crypto_sign_ed25519_amd64_51_30k_batch_2P0,>tt0=int64#1
+# asm 2: movq crypto_sign_ed25519_amd64_51_30k_batch_2P0,>tt0=%rdi
+movq crypto_sign_ed25519_amd64_51_30k_batch_2P0(%rip),%rdi
+
+# qhasm: tt1 = *(uint64 *)&crypto_sign_ed25519_amd64_51_30k_batch_2P1234
+# asm 1: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt1=int64#4
+# asm 2: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt1=%rcx
+movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234(%rip),%rcx
+
+# qhasm: tt2 = *(uint64 *)&crypto_sign_ed25519_amd64_51_30k_batch_2P1234
+# asm 1: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt2=int64#5
+# asm 2: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt2=%r8
+movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234(%rip),%r8
+
+# qhasm: tt3 = *(uint64 *)&crypto_sign_ed25519_amd64_51_30k_batch_2P1234
+# asm 1: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt3=int64#10
+# asm 2: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt3=%r12
+movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234(%rip),%r12
+
+# qhasm: tt4 = *(uint64 *)&crypto_sign_ed25519_amd64_51_30k_batch_2P1234
+# asm 1: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt4=int64#11
+# asm 2: movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234,>tt4=%r13
+movq crypto_sign_ed25519_amd64_51_30k_batch_2P1234(%rip),%r13
+
+# qhasm: tt0 -= tt2d0
+# asm 1: sub  <tt2d0=int64#2,<tt0=int64#1
+# asm 2: sub  <tt2d0=%rsi,<tt0=%rdi
+sub  %rsi,%rdi
+
+# qhasm: tt1 -= tt2d1
+# asm 1: sub  <tt2d1=int64#6,<tt1=int64#4
+# asm 2: sub  <tt2d1=%r9,<tt1=%rcx
+sub  %r9,%rcx
+
+# qhasm: tt2 -= tt2d2
+# asm 1: sub  <tt2d2=int64#7,<tt2=int64#5
+# asm 2: sub  <tt2d2=%rax,<tt2=%r8
+sub  %rax,%r8
+
+# qhasm: tt3 -= tt2d3
+# asm 1: sub  <tt2d3=int64#8,<tt3=int64#10
+# asm 2: sub  <tt2d3=%r10,<tt3=%r12
+sub  %r10,%r12
+
+# qhasm: tt4 -= tt2d4
+# asm 1: sub  <tt2d4=int64#9,<tt4=int64#11
+# asm 2: sub  <tt2d4=%r11,<tt4=%r13
+sub  %r11,%r13
+
+# qhasm: signed<? b - 0
+# asm 1: cmp  $0,<b=int64#3
+# asm 2: cmp  $0,<b=%rdx
+cmp  $0,%rdx
+
+# qhasm: tt2d0 = tt0 if signed<
+# asm 1: cmovl <tt0=int64#1,<tt2d0=int64#2
+# asm 2: cmovl <tt0=%rdi,<tt2d0=%rsi
+cmovl %rdi,%rsi
+
+# qhasm: tt2d1 = tt1 if signed<
+# asm 1: cmovl <tt1=int64#4,<tt2d1=int64#6
+# asm 2: cmovl <tt1=%rcx,<tt2d1=%r9
+cmovl %rcx,%r9
+
+# qhasm: tt2d2 = tt2 if signed<
+# asm 1: cmovl <tt2=int64#5,<tt2d2=int64#7
+# asm 2: cmovl <tt2=%r8,<tt2d2=%rax
+cmovl %r8,%rax
+
+# qhasm: tt2d3 = tt3 if signed<
+# asm 1: cmovl <tt3=int64#10,<tt2d3=int64#8
+# asm 2: cmovl <tt3=%r12,<tt2d3=%r10
+cmovl %r12,%r10
+
+# qhasm: tt2d4 = tt4 if signed<
+# asm 1: cmovl <tt4=int64#11,<tt2d4=int64#9
+# asm 2: cmovl <tt4=%r13,<tt2d4=%r11
+cmovl %r13,%r11
+
+# qhasm: *(uint64 *)(tp + 80) = tt2d0
+# asm 1: movq   <tt2d0=int64#2,80(<tp=int64#15)
+# asm 2: movq   <tt2d0=%rsi,80(<tp=%rbp)
+movq   %rsi,120(%rbp)
+
+# qhasm: *(uint64 *)(tp + 88) = tt2d1
+# asm 1: movq   <tt2d1=int64#6,88(<tp=int64#15)
+# asm 2: movq   <tt2d1=%r9,88(<tp=%rbp)
+movq   %r9,128(%rbp)
+
+# qhasm: *(uint64 *)(tp + 96) = tt2d2
+# asm 1: movq   <tt2d2=int64#7,96(<tp=int64#15)
+# asm 2: movq   <tt2d2=%rax,96(<tp=%rbp)
+movq   %rax,136(%rbp)
+
+# qhasm: *(uint64 *)(tp + 104) = tt2d3
+# asm 1: movq   <tt2d3=int64#8,104(<tp=int64#15)
+# asm 2: movq   <tt2d3=%r10,104(<tp=%rbp)
+movq   %r10,144(%rbp)
+
+# qhasm: *(uint64 *)(tp + 112) = tt2d4
+# asm 1: movq   <tt2d4=int64#9,112(<tp=int64#15)
+# asm 2: movq   <tt2d4=%r11,112(<tp=%rbp)
+movq   %r11,152(%rbp)
+
+# qhasm:   caller1 = caller1_stack
+# asm 1: movq <caller1_stack=stack64#1,>caller1=int64#9
+# asm 2: movq <caller1_stack=0(%rsp),>caller1=%r11
+movq 0(%rsp),%r11
+
+# qhasm:   caller2 = caller2_stack
+# asm 1: movq <caller2_stack=stack64#2,>caller2=int64#10
+# asm 2: movq <caller2_stack=8(%rsp),>caller2=%r12
+movq 8(%rsp),%r12
+
+# qhasm:   caller3 = caller3_stack
+# asm 1: movq <caller3_stack=stack64#3,>caller3=int64#11
+# asm 2: movq <caller3_stack=16(%rsp),>caller3=%r13
+movq 16(%rsp),%r13
+
+# qhasm:   caller4 = caller4_stack
+# asm 1: movq <caller4_stack=stack64#4,>caller4=int64#12
+# asm 2: movq <caller4_stack=24(%rsp),>caller4=%r14
+movq 24(%rsp),%r14
+
+# qhasm:   caller5 = caller5_stack
+# asm 1: movq <caller5_stack=stack64#5,>caller5=int64#13
+# asm 2: movq <caller5_stack=32(%rsp),>caller5=%r15
+movq 32(%rsp),%r15
+
+# qhasm:   caller6 = caller6_stack
+# asm 1: movq <caller6_stack=stack64#6,>caller6=int64#14
+# asm 2: movq <caller6_stack=40(%rsp),>caller6=%rbx
+movq 40(%rsp),%rbx
+
+# qhasm:   caller7 = caller7_stack
+# asm 1: movq <caller7_stack=stack64#7,>caller7=int64#15
+# asm 2: movq <caller7_stack=48(%rsp),>caller7=%rbp
+movq 48(%rsp),%rbp
+
+# qhasm: leave
+add %r11,%rsp
+mov %rdi,%rax
+mov %rsi,%rdx
+ret

--- a/src/amd64/amd64-51-30k.c
+++ b/src/amd64/amd64-51-30k.c
@@ -1,0 +1,65 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file from bench.cr.yp.to/supercop.html (2017-07-25):
+//     Daniel J. Bernstein
+//     Niels Duif
+//     Tanja Lange
+//     lead: Peter Schwabe
+//     Bo-Yin Yang
+
+#include <stddef.h>
+#include "fe25519.h"
+
+/* constants below can be found in various fles in ed25519/amd64-51-30k */
+
+/* d */
+static const fe25519 ecd = {{929955233495203, 466365720129213, 1662059464998953, 2033849074728123, 1442794654840575}};
+/* 2*d */
+static const fe25519 ec2d = {{1859910466990425, 932731440258426, 1072319116312658, 1815898335770999, 633789495995903}};
+/* sqrt(-1) */
+static const fe25519 sqrtm1 = {{1718705420411056, 234908883556509, 2233514472574048, 2117202627021982, 765476049583133}};
+
+#define choose_tp crypto_sign_ed25519_amd64_51_30k_batch_choose_tp
+#include "amd64.c.inc"
+
+int monero_crypto_amd64_51_30k_ge25519_scalarmult(char* out, char const* pub, char const* sec)
+{
+  return scalarmult(out, pub, sec);
+}
+
+int monero_crypto_amd64_51_30k_generate_key_derivation(char* out, char const* tx_pub, char const* view_sec)
+{
+  return generate_key_derivation(out, tx_pub, view_sec);
+}
+
+int monero_crypto_amd64_51_30k_generate_subaddress_public_key(char* out, char const* output_pub, char const* special_sec)
+{
+  return generate_subaddress_public_key(out, output_pub, special_sec);
+}
+

--- a/src/amd64/amd64-64-24k-choose_tp.s
+++ b/src/amd64/amd64-64-24k-choose_tp.s
@@ -1,0 +1,1925 @@
+
+# qhasm: int64 tp
+
+# qhasm: int64 pos
+
+# qhasm: int64 b
+
+# qhasm: int64 basep
+
+# qhasm: input tp
+
+# qhasm: input pos
+
+# qhasm: input b
+
+# qhasm: input basep
+
+# qhasm: int64 mask
+
+# qhasm: int64 u
+
+# qhasm: int64 tysubx0
+
+# qhasm: int64 tysubx1
+
+# qhasm: int64 tysubx2
+
+# qhasm: int64 tysubx3
+
+# qhasm: int64 txaddy0
+
+# qhasm: int64 txaddy1
+
+# qhasm: int64 txaddy2
+
+# qhasm: int64 txaddy3
+
+# qhasm: int64 tt2d0
+
+# qhasm: int64 tt2d1
+
+# qhasm: int64 tt2d2
+
+# qhasm: int64 tt2d3
+
+# qhasm: int64 tt0
+
+# qhasm: int64 tt1
+
+# qhasm: int64 tt2
+
+# qhasm: int64 tt3
+
+# qhasm: int64 subt0
+
+# qhasm: int64 subt1
+
+# qhasm: int64 t
+
+# qhasm: stack64 tp_stack
+
+# qhasm:   int64 caller1
+
+# qhasm:   int64 caller2
+
+# qhasm:   int64 caller3
+
+# qhasm:   int64 caller4
+
+# qhasm:   int64 caller5
+
+# qhasm:   int64 caller6
+
+# qhasm:   int64 caller7
+
+# qhasm:   caller caller1
+
+# qhasm:   caller caller2
+
+# qhasm:   caller caller3
+
+# qhasm:   caller caller4
+
+# qhasm:   caller caller5
+
+# qhasm:   caller caller6
+
+# qhasm:   caller caller7
+
+# qhasm:   stack64 caller1_stack
+
+# qhasm:   stack64 caller2_stack
+
+# qhasm:   stack64 caller3_stack
+
+# qhasm:   stack64 caller4_stack
+
+# qhasm:   stack64 caller5_stack
+
+# qhasm:   stack64 caller6_stack
+
+# qhasm:   stack64 caller7_stack
+
+# qhasm: enter crypto_sign_ed25519_amd64_64_choose_t
+.text
+.p2align 5
+.globl _crypto_sign_ed25519_amd64_64_choose_tp
+.globl crypto_sign_ed25519_amd64_64_choose_tp
+_crypto_sign_ed25519_amd64_64_choose_tp:
+crypto_sign_ed25519_amd64_64_choose_tp:
+mov %rsp,%r11
+and $31,%r11
+add $64,%r11
+sub %r11,%rsp
+
+# qhasm:   caller1_stack = caller1
+# asm 1: movq <caller1=int64#9,>caller1_stack=stack64#1
+# asm 2: movq <caller1=%r11,>caller1_stack=0(%rsp)
+movq %r11,0(%rsp)
+
+# qhasm:   caller2_stack = caller2
+# asm 1: movq <caller2=int64#10,>caller2_stack=stack64#2
+# asm 2: movq <caller2=%r12,>caller2_stack=8(%rsp)
+movq %r12,8(%rsp)
+
+# qhasm:   caller3_stack = caller3
+# asm 1: movq <caller3=int64#11,>caller3_stack=stack64#3
+# asm 2: movq <caller3=%r13,>caller3_stack=16(%rsp)
+movq %r13,16(%rsp)
+
+# qhasm:   caller4_stack = caller4
+# asm 1: movq <caller4=int64#12,>caller4_stack=stack64#4
+# asm 2: movq <caller4=%r14,>caller4_stack=24(%rsp)
+movq %r14,24(%rsp)
+
+# qhasm:   caller5_stack = caller5
+# asm 1: movq <caller5=int64#13,>caller5_stack=stack64#5
+# asm 2: movq <caller5=%r15,>caller5_stack=32(%rsp)
+movq %r15,32(%rsp)
+
+# qhasm:   caller6_stack = caller6
+# asm 1: movq <caller6=int64#14,>caller6_stack=stack64#6
+# asm 2: movq <caller6=%rbx,>caller6_stack=40(%rsp)
+movq %rbx,40(%rsp)
+
+# qhasm:   caller7_stack = caller7
+# asm 1: movq <caller7=int64#15,>caller7_stack=stack64#7
+# asm 2: movq <caller7=%rbp,>caller7_stack=48(%rsp)
+movq %rbp,48(%rsp)
+
+# qhasm: tp_stack = tp
+# asm 1: movq <tp=int64#1,>tp_stack=stack64#8
+# asm 2: movq <tp=%rdi,>tp_stack=56(%rsp)
+movq %rdi,56(%rsp)
+
+# qhasm: pos *= 768
+# asm 1: imulq  $768,<pos=int64#2,>pos=int64#1
+# asm 2: imulq  $768,<pos=%rsi,>pos=%rdi
+imulq  $768,%rsi,%rdi
+
+# qhasm: mask = b
+# asm 1: mov  <b=int64#3,>mask=int64#2
+# asm 2: mov  <b=%rdx,>mask=%rsi
+mov  %rdx,%rsi
+
+# qhasm: (int64) mask >>= 7
+# asm 1: sar  $7,<mask=int64#2
+# asm 2: sar  $7,<mask=%rsi
+sar  $7,%rsi
+
+# qhasm: u = b
+# asm 1: mov  <b=int64#3,>u=int64#5
+# asm 2: mov  <b=%rdx,>u=%r8
+mov  %rdx,%r8
+
+# qhasm: u += mask
+# asm 1: add  <mask=int64#2,<u=int64#5
+# asm 2: add  <mask=%rsi,<u=%r8
+add  %rsi,%r8
+
+# qhasm: u ^= mask
+# asm 1: xor  <mask=int64#2,<u=int64#5
+# asm 2: xor  <mask=%rsi,<u=%r8
+xor  %rsi,%r8
+
+# qhasm: tysubx0 = 1
+# asm 1: mov  $1,>tysubx0=int64#2
+# asm 2: mov  $1,>tysubx0=%rsi
+mov  $1,%rsi
+
+# qhasm: tysubx1 = 0
+# asm 1: mov  $0,>tysubx1=int64#6
+# asm 2: mov  $0,>tysubx1=%r9
+mov  $0,%r9
+
+# qhasm: tysubx2 = 0
+# asm 1: mov  $0,>tysubx2=int64#7
+# asm 2: mov  $0,>tysubx2=%rax
+mov  $0,%rax
+
+# qhasm: tysubx3 = 0
+# asm 1: mov  $0,>tysubx3=int64#8
+# asm 2: mov  $0,>tysubx3=%r10
+mov  $0,%r10
+
+# qhasm: txaddy0 = 1
+# asm 1: mov  $1,>txaddy0=int64#9
+# asm 2: mov  $1,>txaddy0=%r11
+mov  $1,%r11
+
+# qhasm: txaddy1 = 0
+# asm 1: mov  $0,>txaddy1=int64#10
+# asm 2: mov  $0,>txaddy1=%r12
+mov  $0,%r12
+
+# qhasm: txaddy2 = 0
+# asm 1: mov  $0,>txaddy2=int64#11
+# asm 2: mov  $0,>txaddy2=%r13
+mov  $0,%r13
+
+# qhasm: txaddy3 = 0
+# asm 1: mov  $0,>txaddy3=int64#12
+# asm 2: mov  $0,>txaddy3=%r14
+mov  $0,%r14
+
+# qhasm: =? u - 1
+# asm 1: cmp  $1,<u=int64#5
+# asm 2: cmp  $1,<u=%r8
+cmp  $1,%r8
+
+# qhasm: t = *(uint64 *)(basep + 0 + pos)
+# asm 1: movq   0(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   0(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   0(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 8 + pos)
+# asm 1: movq   8(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   8(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   8(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 16 + pos)
+# asm 1: movq   16(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   16(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   16(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 24 + pos)
+# asm 1: movq   24(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   24(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   24(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 32 + pos)
+# asm 1: movq   32(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   32(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   32(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 40 + pos)
+# asm 1: movq   40(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   40(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   40(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 48 + pos)
+# asm 1: movq   48(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   48(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   48(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 56 + pos)
+# asm 1: movq   56(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   56(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   56(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: =? u - 2
+# asm 1: cmp  $2,<u=int64#5
+# asm 2: cmp  $2,<u=%r8
+cmp  $2,%r8
+
+# qhasm: t = *(uint64 *)(basep + 128 + pos)
+# asm 1: movq   128(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   128(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   128(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 136 + pos)
+# asm 1: movq   136(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   136(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   136(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 144 + pos)
+# asm 1: movq   144(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   144(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   144(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 152 + pos)
+# asm 1: movq   152(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   152(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   152(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 160 + pos)
+# asm 1: movq   160(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   160(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   160(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 168 + pos)
+# asm 1: movq   168(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   168(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   168(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 176 + pos)
+# asm 1: movq   176(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   176(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   176(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 184 + pos)
+# asm 1: movq   184(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   184(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   184(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: =? u - 3
+# asm 1: cmp  $3,<u=int64#5
+# asm 2: cmp  $3,<u=%r8
+cmp  $3,%r8
+
+# qhasm: t = *(uint64 *)(basep + 256 + pos)
+# asm 1: movq   256(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   256(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   256(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 264 + pos)
+# asm 1: movq   264(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   264(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   264(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 272 + pos)
+# asm 1: movq   272(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   272(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   272(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 280 + pos)
+# asm 1: movq   280(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   280(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   280(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 288 + pos)
+# asm 1: movq   288(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   288(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   288(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 296 + pos)
+# asm 1: movq   296(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   296(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   296(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 304 + pos)
+# asm 1: movq   304(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   304(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   304(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 312 + pos)
+# asm 1: movq   312(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   312(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   312(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: =? u - 4
+# asm 1: cmp  $4,<u=int64#5
+# asm 2: cmp  $4,<u=%r8
+cmp  $4,%r8
+
+# qhasm: t = *(uint64 *)(basep + 384 + pos)
+# asm 1: movq   384(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   384(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   384(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 392 + pos)
+# asm 1: movq   392(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   392(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   392(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 400 + pos)
+# asm 1: movq   400(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   400(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   400(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 408 + pos)
+# asm 1: movq   408(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   408(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   408(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 416 + pos)
+# asm 1: movq   416(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   416(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   416(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 424 + pos)
+# asm 1: movq   424(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   424(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   424(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 432 + pos)
+# asm 1: movq   432(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   432(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   432(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 440 + pos)
+# asm 1: movq   440(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   440(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   440(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: =? u - 5
+# asm 1: cmp  $5,<u=int64#5
+# asm 2: cmp  $5,<u=%r8
+cmp  $5,%r8
+
+# qhasm: t = *(uint64 *)(basep + 512 + pos)
+# asm 1: movq   512(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   512(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   512(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 520 + pos)
+# asm 1: movq   520(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   520(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   520(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 528 + pos)
+# asm 1: movq   528(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   528(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   528(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 536 + pos)
+# asm 1: movq   536(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   536(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   536(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 544 + pos)
+# asm 1: movq   544(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   544(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   544(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 552 + pos)
+# asm 1: movq   552(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   552(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   552(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 560 + pos)
+# asm 1: movq   560(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   560(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   560(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 568 + pos)
+# asm 1: movq   568(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   568(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   568(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: =? u - 6
+# asm 1: cmp  $6,<u=int64#5
+# asm 2: cmp  $6,<u=%r8
+cmp  $6,%r8
+
+# qhasm: t = *(uint64 *)(basep + 640 + pos)
+# asm 1: movq   640(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   640(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   640(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 648 + pos)
+# asm 1: movq   648(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   648(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   648(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 656 + pos)
+# asm 1: movq   656(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   656(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   656(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 664 + pos)
+# asm 1: movq   664(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   664(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   664(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 672 + pos)
+# asm 1: movq   672(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   672(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   672(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 680 + pos)
+# asm 1: movq   680(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   680(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   680(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 688 + pos)
+# asm 1: movq   688(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   688(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   688(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 696 + pos)
+# asm 1: movq   696(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   696(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   696(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: =? u - 7
+# asm 1: cmp  $7,<u=int64#5
+# asm 2: cmp  $7,<u=%r8
+cmp  $7,%r8
+
+# qhasm: t = *(uint64 *)(basep + 768 + pos)
+# asm 1: movq   768(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   768(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   768(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 776 + pos)
+# asm 1: movq   776(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   776(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   776(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 784 + pos)
+# asm 1: movq   784(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   784(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   784(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 792 + pos)
+# asm 1: movq   792(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   792(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   792(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 800 + pos)
+# asm 1: movq   800(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   800(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   800(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 808 + pos)
+# asm 1: movq   808(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   808(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   808(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 816 + pos)
+# asm 1: movq   816(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   816(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   816(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 824 + pos)
+# asm 1: movq   824(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   824(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   824(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: =? u - 8
+# asm 1: cmp  $8,<u=int64#5
+# asm 2: cmp  $8,<u=%r8
+cmp  $8,%r8
+
+# qhasm: t = *(uint64 *)(basep + 896 + pos)
+# asm 1: movq   896(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   896(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   896(%rcx,%rdi),%r15
+
+# qhasm: tysubx0 = t if =
+# asm 1: cmove <t=int64#13,<tysubx0=int64#2
+# asm 2: cmove <t=%r15,<tysubx0=%rsi
+cmove %r15,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 904 + pos)
+# asm 1: movq   904(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   896(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   904(%rcx,%rdi),%r15
+
+# qhasm: tysubx1 = t if =
+# asm 1: cmove <t=int64#13,<tysubx1=int64#6
+# asm 2: cmove <t=%r15,<tysubx1=%r9
+cmove %r15,%r9
+
+# qhasm: t = *(uint64 *)(basep + 912 + pos)
+# asm 1: movq   912(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   912(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   912(%rcx,%rdi),%r15
+
+# qhasm: tysubx2 = t if =
+# asm 1: cmove <t=int64#13,<tysubx2=int64#7
+# asm 2: cmove <t=%r15,<tysubx2=%rax
+cmove %r15,%rax
+
+# qhasm: t = *(uint64 *)(basep + 920 + pos)
+# asm 1: movq   920(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   920(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   920(%rcx,%rdi),%r15
+
+# qhasm: tysubx3 = t if =
+# asm 1: cmove <t=int64#13,<tysubx3=int64#8
+# asm 2: cmove <t=%r15,<tysubx3=%r10
+cmove %r15,%r10
+
+# qhasm: t = *(uint64 *)(basep + 928 + pos)
+# asm 1: movq   928(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   928(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   928(%rcx,%rdi),%r15
+
+# qhasm: txaddy0 = t if =
+# asm 1: cmove <t=int64#13,<txaddy0=int64#9
+# asm 2: cmove <t=%r15,<txaddy0=%r11
+cmove %r15,%r11
+
+# qhasm: t = *(uint64 *)(basep + 936 + pos)
+# asm 1: movq   936(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   936(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   936(%rcx,%rdi),%r15
+
+# qhasm: txaddy1 = t if =
+# asm 1: cmove <t=int64#13,<txaddy1=int64#10
+# asm 2: cmove <t=%r15,<txaddy1=%r12
+cmove %r15,%r12
+
+# qhasm: t = *(uint64 *)(basep + 944 + pos)
+# asm 1: movq   944(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   944(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   944(%rcx,%rdi),%r15
+
+# qhasm: txaddy2 = t if =
+# asm 1: cmove <t=int64#13,<txaddy2=int64#11
+# asm 2: cmove <t=%r15,<txaddy2=%r13
+cmove %r15,%r13
+
+# qhasm: t = *(uint64 *)(basep + 952 + pos)
+# asm 1: movq   952(<basep=int64#4,<pos=int64#1),>t=int64#13
+# asm 2: movq   952(<basep=%rcx,<pos=%rdi),>t=%r15
+movq   952(%rcx,%rdi),%r15
+
+# qhasm: txaddy3 = t if =
+# asm 1: cmove <t=int64#13,<txaddy3=int64#12
+# asm 2: cmove <t=%r15,<txaddy3=%r14
+cmove %r15,%r14
+
+# qhasm: signed<? b - 0
+# asm 1: cmp  $0,<b=int64#3
+# asm 2: cmp  $0,<b=%rdx
+cmp  $0,%rdx
+
+# qhasm: t = tysubx0
+# asm 1: mov  <tysubx0=int64#2,>t=int64#13
+# asm 2: mov  <tysubx0=%rsi,>t=%r15
+mov  %rsi,%r15
+
+# qhasm: tysubx0 = txaddy0 if signed<
+# asm 1: cmovl <txaddy0=int64#9,<tysubx0=int64#2
+# asm 2: cmovl <txaddy0=%r11,<tysubx0=%rsi
+cmovl %r11,%rsi
+
+# qhasm: txaddy0 = t if signed<
+# asm 1: cmovl <t=int64#13,<txaddy0=int64#9
+# asm 2: cmovl <t=%r15,<txaddy0=%r11
+cmovl %r15,%r11
+
+# qhasm: t = tysubx1
+# asm 1: mov  <tysubx1=int64#6,>t=int64#13
+# asm 2: mov  <tysubx1=%r9,>t=%r15
+mov  %r9,%r15
+
+# qhasm: tysubx1 = txaddy1 if signed<
+# asm 1: cmovl <txaddy1=int64#10,<tysubx1=int64#6
+# asm 2: cmovl <txaddy1=%r12,<tysubx1=%r9
+cmovl %r12,%r9
+
+# qhasm: txaddy1 = t if signed<
+# asm 1: cmovl <t=int64#13,<txaddy1=int64#10
+# asm 2: cmovl <t=%r15,<txaddy1=%r12
+cmovl %r15,%r12
+
+# qhasm: t = tysubx2
+# asm 1: mov  <tysubx2=int64#7,>t=int64#13
+# asm 2: mov  <tysubx2=%rax,>t=%r15
+mov  %rax,%r15
+
+# qhasm: tysubx2 = txaddy2 if signed<
+# asm 1: cmovl <txaddy2=int64#11,<tysubx2=int64#7
+# asm 2: cmovl <txaddy2=%r13,<tysubx2=%rax
+cmovl %r13,%rax
+
+# qhasm: txaddy2 = t if signed<
+# asm 1: cmovl <t=int64#13,<txaddy2=int64#11
+# asm 2: cmovl <t=%r15,<txaddy2=%r13
+cmovl %r15,%r13
+
+# qhasm: t = tysubx3
+# asm 1: mov  <tysubx3=int64#8,>t=int64#13
+# asm 2: mov  <tysubx3=%r10,>t=%r15
+mov  %r10,%r15
+
+# qhasm: tysubx3 = txaddy3 if signed<
+# asm 1: cmovl <txaddy3=int64#12,<tysubx3=int64#8
+# asm 2: cmovl <txaddy3=%r14,<tysubx3=%r10
+cmovl %r14,%r10
+
+# qhasm: txaddy3 = t if signed<
+# asm 1: cmovl <t=int64#13,<txaddy3=int64#12
+# asm 2: cmovl <t=%r15,<txaddy3=%r14
+cmovl %r15,%r14
+
+# qhasm: tp = tp_stack
+# asm 1: movq <tp_stack=stack64#8,>tp=int64#13
+# asm 2: movq <tp_stack=56(%rsp),>tp=%r15
+movq 56(%rsp),%r15
+
+# qhasm: *(uint64 *)(tp + 0) = tysubx0
+# asm 1: movq   <tysubx0=int64#2,0(<tp=int64#13)
+# asm 2: movq   <tysubx0=%rsi,0(<tp=%r15)
+movq   %rsi,0(%r15)
+
+# qhasm: *(uint64 *)(tp + 8) = tysubx1
+# asm 1: movq   <tysubx1=int64#6,8(<tp=int64#13)
+# asm 2: movq   <tysubx1=%r9,8(<tp=%r15)
+movq   %r9,8(%r15)
+
+# qhasm: *(uint64 *)(tp + 16) = tysubx2
+# asm 1: movq   <tysubx2=int64#7,16(<tp=int64#13)
+# asm 2: movq   <tysubx2=%rax,16(<tp=%r15)
+movq   %rax,16(%r15)
+
+# qhasm: *(uint64 *)(tp + 24) = tysubx3
+# asm 1: movq   <tysubx3=int64#8,24(<tp=int64#13)
+# asm 2: movq   <tysubx3=%r10,24(<tp=%r15)
+movq   %r10,24(%r15)
+
+# qhasm: *(uint64 *)(tp + 32) = txaddy0
+# asm 1: movq   <txaddy0=int64#9,32(<tp=int64#13)
+# asm 2: movq   <txaddy0=%r11,32(<tp=%r15)
+movq   %r11,32(%r15)
+
+# qhasm: *(uint64 *)(tp + 40) = txaddy1
+# asm 1: movq   <txaddy1=int64#10,40(<tp=int64#13)
+# asm 2: movq   <txaddy1=%r12,40(<tp=%r15)
+movq   %r12,40(%r15)
+
+# qhasm: *(uint64 *)(tp + 48) = txaddy2
+# asm 1: movq   <txaddy2=int64#11,48(<tp=int64#13)
+# asm 2: movq   <txaddy2=%r13,48(<tp=%r15)
+movq   %r13,48(%r15)
+
+# qhasm: *(uint64 *)(tp + 56) = txaddy3
+# asm 1: movq   <txaddy3=int64#12,56(<tp=int64#13)
+# asm 2: movq   <txaddy3=%r14,56(<tp=%r15)
+movq   %r14,56(%r15)
+
+# qhasm: tt2d0 = 0
+# asm 1: mov  $0,>tt2d0=int64#2
+# asm 2: mov  $0,>tt2d0=%rsi
+mov  $0,%rsi
+
+# qhasm: tt2d1 = 0
+# asm 1: mov  $0,>tt2d1=int64#6
+# asm 2: mov  $0,>tt2d1=%r9
+mov  $0,%r9
+
+# qhasm: tt2d2 = 0
+# asm 1: mov  $0,>tt2d2=int64#7
+# asm 2: mov  $0,>tt2d2=%rax
+mov  $0,%rax
+
+# qhasm: tt2d3 = 0
+# asm 1: mov  $0,>tt2d3=int64#8
+# asm 2: mov  $0,>tt2d3=%r10
+mov  $0,%r10
+
+# qhasm: tz0 = 1
+# asm 1: mov  $0,>tz0=int64#1
+# asm 2: mov  $0,>tz0=%rbp
+mov  $1,%rbp
+
+# qhasm: tz1 = 0
+# asm 1: mov  $0,>tz1=int64#4
+# asm 2: mov  $0,>tz1=%r12
+mov  $0,%r12
+
+# qhasm: tz2 = 0
+# asm 1: mov  $0,>tz2=int64#5
+# asm 2: mov  $0,>tz2=%r13
+mov  $0,%r13
+
+# qhasm: tz3 = 0
+# asm 1: mov  $0,>tz3=int64#9
+# asm 2: mov  $0,>tz3=%r14
+mov  $0,%r14
+
+# qhasm: =? u - 1
+# asm 1: cmp  $1,<u=int64#5
+# asm 2: cmp  $1,<u=%r8
+cmp  $1,%r8
+
+# qhasm: t = *(uint64 *)(basep + 64 + pos)
+# asm 1: movq   64(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   64(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   64(%rcx,%rdi),%r11
+
+# qhasm: z0 = t if =
+# asm 1: cmove <t=int64#9,<z0=int64#2
+# asm 2: cmove <t=%r11,<z0=%rbp
+cmove %r11,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 72 + pos)
+# asm 1: movq   72(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   72(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   72(%rcx,%rdi),%r11
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#9,<tz1=int64#6
+# asm 2: cmove <t=%r11,<tz1=%r12
+cmove %r11,%r12
+
+# qhasm: t = *(uint64 *)(basep + 80 + pos)
+# asm 1: movq   80(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   80(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   80(%rcx,%rdi),%r11
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#9,<tz2=int64#7
+# asm 2: cmove <t=%r11,<tz2=%r13
+cmove %r11,%r13
+
+# qhasm: t = *(uint64 *)(basep + 88 + pos)
+# asm 1: movq   88(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   88(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   88(%rcx,%rdi),%r11
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#9,<tz3=int64#8
+# asm 2: cmove <t=%r11,<tz3=%r14
+cmove %r11,%r14
+
+# qhasm: t = *(uint64 *)(basep + 96 + pos)
+# asm 1: movq   96(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   96(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   96(%rcx,%rdi),%r11
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#9,<tt2d0=int64#2
+# asm 2: cmove <t=%r11,<tt2d0=%rsi
+cmove %r11,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 104 + pos)
+# asm 1: movq   104(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   104(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   104(%rcx,%rdi),%r11
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#9,<tt2d1=int64#6
+# asm 2: cmove <t=%r11,<tt2d1=%r9
+cmove %r11,%r9
+
+# qhasm: t = *(uint64 *)(basep + 112 + pos)
+# asm 1: movq   112(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   112(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   112(%rcx,%rdi),%r11
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#9,<tt2d2=int64#7
+# asm 2: cmove <t=%r11,<tt2d2=%rax
+cmove %r11,%rax
+
+# qhasm: t = *(uint64 *)(basep + 120 + pos)
+# asm 1: movq   120(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   120(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   120(%rcx,%rdi),%r11
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#9,<tt2d3=int64#8
+# asm 2: cmove <t=%r11,<tt2d3=%r10
+cmove %r11,%r10
+
+# qhasm: =? u - 2
+# asm 1: cmp  $2,<u=int64#5
+# asm 2: cmp  $2,<u=%r8
+cmp  $2,%r8
+
+# qhasm: t = *(uint64 *)(basep + 192 + pos)
+# asm 1: movq   192(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   192(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   192(%rcx,%rdi),%r11
+
+# qhasm: tz0 = t if =
+# asm 1: cmove <t=int64#9,<tz0=int64#2
+# asm 2: cmove <t=%r11,<tz0=%rbp
+cmove %r11,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 200 + pos)
+# asm 1: movq   200(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   200(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   200(%rcx,%rdi),%r11
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#9,<tz1=int64#6
+# asm 2: cmove <t=%r11,<tz1=%r12
+cmove %r11,%r12
+
+# qhasm: t = *(uint64 *)(basep + 208 + pos)
+# asm 1: movq   208(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   208(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   208(%rcx,%rdi),%r11
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#9,<tz2=int64#7
+# asm 2: cmove <t=%r11,<tz2=%r13
+cmove %r11,%r13
+
+# qhasm: t = *(uint64 *)(basep + 216 + pos)
+# asm 1: movq   216(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   216(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   216(%rcx,%rdi),%r11
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#9,<tz3=int64#8
+# asm 2: cmove <t=%r11,<tz3=%r14
+cmove %r11,%r14
+
+# qhasm: t = *(uint64 *)(basep + 224 + pos)
+# asm 1: movq   224(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   224(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   224(%rcx,%rdi),%r11
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#9,<tt2d0=int64#2
+# asm 2: cmove <t=%r11,<tt2d0=%rsi
+cmove %r11,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 232 + pos)
+# asm 1: movq   232(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   232(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   232(%rcx,%rdi),%r11
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#9,<tt2d1=int64#6
+# asm 2: cmove <t=%r11,<tt2d1=%r9
+cmove %r11,%r9
+
+# qhasm: t = *(uint64 *)(basep + 240 + pos)
+# asm 1: movq   240(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   240(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   240(%rcx,%rdi),%r11
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#9,<tt2d2=int64#7
+# asm 2: cmove <t=%r11,<tt2d2=%rax
+cmove %r11,%rax
+
+# qhasm: t = *(uint64 *)(basep + 248 + pos)
+# asm 1: movq   248(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   248(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   248(%rcx,%rdi),%r11
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#9,<tt2d3=int64#8
+# asm 2: cmove <t=%r11,<tt2d3=%r10
+cmove %r11,%r10
+
+# qhasm: =? u - 3
+# asm 1: cmp  $3,<u=int64#5
+# asm 2: cmp  $3,<u=%r8
+cmp  $3,%r8
+
+# qhasm: t = *(uint64 *)(basep + 320 + pos)
+# asm 1: movq   320(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   320(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   320(%rcx,%rdi),%r11
+
+# qhasm: tz0 = t if =
+# asm 1: cmove <t=int64#9,<tz0=int64#2
+# asm 2: cmove <t=%r11,<tz0=%rbp
+cmove %r11,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 328 + pos)
+# asm 1: movq   328(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   328(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   328(%rcx,%rdi),%r11
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#9,<tz1=int64#6
+# asm 2: cmove <t=%r11,<tz1=%r12
+cmove %r11,%r12
+
+# qhasm: t = *(uint64 *)(basep + 336 + pos)
+# asm 1: movq   336(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   336(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   336(%rcx,%rdi),%r11
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#9,<tz2=int64#7
+# asm 2: cmove <t=%r11,<tz2=%r13
+cmove %r11,%r13
+
+# qhasm: t = *(uint64 *)(basep + 344 + pos)
+# asm 1: movq   344(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   344(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   344(%rcx,%rdi),%r11
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#9,<tz3=int64#8
+# asm 2: cmove <t=%r11,<tz3=%r14
+cmove %r11,%r14
+
+# qhasm: t = *(uint64 *)(basep + 352 + pos)
+# asm 1: movq   352(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   352(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   352(%rcx,%rdi),%r11
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#9,<tt2d0=int64#2
+# asm 2: cmove <t=%r11,<tt2d0=%rsi
+cmove %r11,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 360 + pos)
+# asm 1: movq   360(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   360(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   360(%rcx,%rdi),%r11
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#9,<tt2d1=int64#6
+# asm 2: cmove <t=%r11,<tt2d1=%r9
+cmove %r11,%r9
+
+# qhasm: t = *(uint64 *)(basep + 368 + pos)
+# asm 1: movq   368(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   368(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   368(%rcx,%rdi),%r11
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#9,<tt2d2=int64#7
+# asm 2: cmove <t=%r11,<tt2d2=%rax
+cmove %r11,%rax
+
+# qhasm: t = *(uint64 *)(basep + 376 + pos)
+# asm 1: movq   376(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   376(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   376(%rcx,%rdi),%r11
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#9,<tt2d3=int64#8
+# asm 2: cmove <t=%r11,<tt2d3=%r10
+cmove %r11,%r10
+
+# qhasm: =? u - 4
+# asm 1: cmp  $4,<u=int64#5
+# asm 2: cmp  $4,<u=%r8
+cmp  $4,%r8
+
+# qhasm: t = *(uint64 *)(basep + 448 + pos)
+# asm 1: movq   448(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   448(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   448(%rcx,%rdi),%r11
+
+# qhasm: tz0 = t if =
+# asm 1: cmove <t=int64#9,<z0=int64#2
+# asm 2: cmove <t=%r11,<tz0=%rsi
+cmove %r11,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 456 + pos)
+# asm 1: movq   456(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   456(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   456(%rcx,%rdi),%r11
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#9,<tz1=int64#6
+# asm 2: cmove <t=%r11,<tz1=%r12
+cmove %r11,%r12
+
+# qhasm: t = *(uint64 *)(basep + 464 + pos)
+# asm 1: movq   464(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   464(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   464(%rcx,%rdi),%r11
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#9,<tz2=int64#7
+# asm 2: cmove <t=%r11,<tz2=%r13
+cmove %r11,%r13
+
+# qhasm: t = *(uint64 *)(basep + 472 + pos)
+# asm 1: movq   472(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   472(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   472(%rcx,%rdi),%r11
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#9,<tz3=int64#8
+# asm 2: cmove <t=%r11,<tz3=%r10
+cmove %r11,%r14
+
+# qhasm: t = *(uint64 *)(basep + 480 + pos)
+# asm 1: movq   480(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   480(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   480(%rcx,%rdi),%r11
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#9,<tt2d0=int64#2
+# asm 2: cmove <t=%r11,<tt2d0=%rsi
+cmove %r11,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 488 + pos)
+# asm 1: movq   488(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   488(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   488(%rcx,%rdi),%r11
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#9,<tt2d1=int64#6
+# asm 2: cmove <t=%r11,<tt2d1=%r9
+cmove %r11,%r9
+
+# qhasm: t = *(uint64 *)(basep + 496 + pos)
+# asm 1: movq   496(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   496(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   496(%rcx,%rdi),%r11
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#9,<tt2d2=int64#7
+# asm 2: cmove <t=%r11,<tt2d2=%rax
+cmove %r11,%rax
+
+# qhasm: t = *(uint64 *)(basep + 504 + pos)
+# asm 1: movq   504(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   504(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   504(%rcx,%rdi),%r11
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#9,<tt2d3=int64#8
+# asm 2: cmove <t=%r11,<tt2d3=%r10
+cmove %r11,%r10
+
+# qhasm: =? u - 5
+# asm 1: cmp  $5,<u=int64#5
+# asm 2: cmp  $5,<u=%r8
+cmp  $5,%r8
+
+# qhasm: t = *(uint64 *)(basep + 576 + pos)
+# asm 1: movq   576(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   576(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   576(%rcx,%rdi),%r11
+
+# qhasm: tz0 = t if =
+# asm 1: cmove <t=int64#9,<tz0=int64#2
+# asm 2: cmove <t=%r11,<tz0=%rbp
+cmove %r11,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 584 + pos)
+# asm 1: movq   584(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   584(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   584(%rcx,%rdi),%r11
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#9,<tz1=int64#6
+# asm 2: cmove <t=%r11,<tz1=%r12
+cmove %r11,%r12
+
+# qhasm: t = *(uint64 *)(basep + 592 + pos)
+# asm 1: movq   592(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   592(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   592(%rcx,%rdi),%r11
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#9,<tz2=int64#7
+# asm 2: cmove <t=%r11,<tz2=%r13
+cmove %r11,%r13
+
+# qhasm: t = *(uint64 *)(basep + 600 + pos)
+# asm 1: movq   600(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   600(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   600(%rcx,%rdi),%r11
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#9,<tz3=int64#8
+# asm 2: cmove <t=%r11,<tz3=%r10
+cmove %r11,%r14
+
+# qhasm: t = *(uint64 *)(basep + 608 + pos)
+# asm 1: movq   608(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   608(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   608(%rcx,%rdi),%r11
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#9,<tt2d0=int64#2
+# asm 2: cmove <t=%r11,<tt2d0=%rsi
+cmove %r11,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 616 + pos)
+# asm 1: movq   616(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   616(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   616(%rcx,%rdi),%r11
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#9,<tt2d1=int64#6
+# asm 2: cmove <t=%r11,<tt2d1=%r9
+cmove %r11,%r9
+
+# qhasm: t = *(uint64 *)(basep + 624 + pos)
+# asm 1: movq   624(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   624(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   624(%rcx,%rdi),%r11
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#9,<tt2d2=int64#7
+# asm 2: cmove <t=%r11,<tt2d2=%rax
+cmove %r11,%rax
+
+# qhasm: t = *(uint64 *)(basep + 632 + pos)
+# asm 1: movq   632(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   632(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   632(%rcx,%rdi),%r11
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#9,<tt2d3=int64#8
+# asm 2: cmove <t=%r11,<tt2d3=%r10
+cmove %r11,%r10
+
+# qhasm: =? u - 6
+# asm 1: cmp  $6,<u=int64#5
+# asm 2: cmp  $6,<u=%r8
+cmp  $6,%r8
+
+# qhasm: t = *(uint64 *)(basep + 704 + pos)
+# asm 1: movq   704(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   704(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   704(%rcx,%rdi),%r11
+
+# qhasm: tz0 = t if =
+# asm 1: cmove <t=int64#9,<tz0=int64#2
+# asm 2: cmove <t=%r11,<tz0=%rbp
+cmove %r11,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 712 + pos)
+# asm 1: movq   712(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   712(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   712(%rcx,%rdi),%r11
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#9,<tz1=int64#6
+# asm 2: cmove <t=%r11,<tz1=%r12
+cmove %r11,%r12
+
+# qhasm: t = *(uint64 *)(basep + 720 + pos)
+# asm 1: movq   720(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   720(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   720(%rcx,%rdi),%r11
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#9,<tz2=int64#7
+# asm 2: cmove <t=%r11,<tz2=%r13
+cmove %r11,%r13
+
+# qhasm: t = *(uint64 *)(basep + 728 + pos)
+# asm 1: movq   728(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   728(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   728(%rcx,%rdi),%r11
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#9,<tz3=int64#7
+# asm 2: cmove <t=%r11,<tz3=%r14
+cmove %r11,%r14
+
+# qhasm: t = *(uint64 *)(basep + 736 + pos)
+# asm 1: movq   736(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   736(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   736(%rcx,%rdi),%r11
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#9,<tt2d0=int64#2
+# asm 2: cmove <t=%r11,<tt2d0=%rsi
+cmove %r11,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 744 + pos)
+# asm 1: movq   744(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   744(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   744(%rcx,%rdi),%r11
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#9,<tt2d1=int64#6
+# asm 2: cmove <t=%r11,<tt2d1=%r9
+cmove %r11,%r9
+
+# qhasm: t = *(uint64 *)(basep + 752 + pos)
+# asm 1: movq   752(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   752(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   752(%rcx,%rdi),%r11
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#9,<tt2d2=int64#7
+# asm 2: cmove <t=%r11,<tt2d2=%rax
+cmove %r11,%rax
+
+# qhasm: t = *(uint64 *)(basep + 760 + pos)
+# asm 1: movq   760(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   760(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   760(%rcx,%rdi),%r11
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#9,<tt2d3=int64#8
+# asm 2: cmove <t=%r11,<tt2d3=%r10
+cmove %r11,%r10
+
+# qhasm: =? u - 7
+# asm 1: cmp  $7,<u=int64#5
+# asm 2: cmp  $7,<u=%r8
+cmp  $7,%r8
+
+# qhasm: t = *(uint64 *)(basep + 832 + pos)
+# asm 1: movq   832(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   832(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   832(%rcx,%rdi),%r11
+
+# qhasm: tz0 = t if =
+# asm 1: cmove <t=int64#9,<tz0=int64#2
+# asm 2: cmove <t=%r11,<tz0=%rsi
+cmove %r11,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 840 + pos)
+# asm 1: movq   840(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   840(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   840(%rcx,%rdi),%r11
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#9,<tz1=int64#6
+# asm 2: cmove <t=%r11,<tz1=%r9
+cmove %r11,%r12
+
+# qhasm: t = *(uint64 *)(basep + 848 + pos)
+# asm 1: movq   848(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   848(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   848(%rcx,%rdi),%r11
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#9,<tz2=int64#7
+# asm 2: cmove <t=%r11,<tz2=%rax
+cmove %r11,%r13
+
+# qhasm: t = *(uint64 *)(basep + 856 + pos)
+# asm 1: movq   856(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   856(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   856(%rcx,%rdi),%r11
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#9,<tz3=int64#8
+# asm 2: cmove <t=%r11,<tz3=%r10
+cmove %r11,%r14
+
+# qhasm: t = *(uint64 *)(basep + 864 + pos)
+# asm 1: movq   864(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   864(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   864(%rcx,%rdi),%r11
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#9,<tt2d0=int64#2
+# asm 2: cmove <t=%r11,<tt2d0=%rsi
+cmove %r11,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 872 + pos)
+# asm 1: movq   872(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   872(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   872(%rcx,%rdi),%r11
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#9,<tt2d1=int64#6
+# asm 2: cmove <t=%r11,<tt2d1=%r9
+cmove %r11,%r9
+
+# qhasm: t = *(uint64 *)(basep + 880 + pos)
+# asm 1: movq   880(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   880(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   880(%rcx,%rdi),%r11
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#9,<tt2d2=int64#7
+# asm 2: cmove <t=%r11,<tt2d2=%rax
+cmove %r11,%rax
+
+# qhasm: t = *(uint64 *)(basep + 888 + pos)
+# asm 1: movq   88(<basep=int64#4,<pos=int64#1),>t=int64#9
+# asm 2: movq   88(<basep=%rcx,<pos=%rdi),>t=%r11
+movq   888(%rcx,%rdi),%r11
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#9,<tt2d3=int64#8
+# asm 2: cmove <t=%r11,<tt2d3=%r10
+cmove %r11,%r10
+
+# qhasm: =? u - 8
+# asm 1: cmp  $8,<u=int64#5
+# asm 2: cmp  $8,<u=%r8
+cmp  $8,%r8
+
+# qhasm: t = *(uint64 *)(basep + 960 + pos)
+# asm 1: movq   960(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   960(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   960(%rcx,%rdi),%r8
+
+# qhasm: tz0 = t if =
+# asm 1: cmove <t=int64#5,<tz0=int64#2
+# asm 2: cmove <t=%r8,<tz0=%rsi
+cmove %r8,%rbp
+
+# qhasm: t = *(uint64 *)(basep + 968 + pos)
+# asm 1: movq   968(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   968(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   968(%rcx,%rdi),%r8
+
+# qhasm: tz1 = t if =
+# asm 1: cmove <t=int64#5,<tz1=int64#6
+# asm 2: cmove <t=%r8,<tz1=%r9
+cmove %r8,%r12
+
+# qhasm: t = *(uint64 *)(basep + 976 + pos)
+# asm 1: movq   976(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   976(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   976(%rcx,%rdi),%r8
+
+# qhasm: tz2 = t if =
+# asm 1: cmove <t=int64#5,<tz2=int64#7
+# asm 2: cmove <t=%r8,<tz2=%rax
+cmove %r8,%r13
+
+# qhasm: t = *(uint64 *)(basep + 984 + pos)
+# asm 1: movq   984(<basep=int64#4,<pos=int64#1),>t=int64#1
+# asm 2: movq   984(<basep=%rcx,<pos=%r8),>t=%r14
+movq   984(%rcx,%rdi),%r8
+
+# qhasm: tz3 = t if =
+# asm 1: cmove <t=int64#1,<tz3=int64#8
+# asm 2: cmove <t=%r8,<tz3=%r10
+cmove %r8,%r14
+
+# qhasm: t = *(uint64 *)(basep + 992 + pos)
+# asm 1: movq   992(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   992(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   992(%rcx,%rdi),%r8
+
+# qhasm: tt2d0 = t if =
+# asm 1: cmove <t=int64#5,<tt2d0=int64#2
+# asm 2: cmove <t=%r8,<tt2d0=%rsi
+cmove %r8,%rsi
+
+# qhasm: t = *(uint64 *)(basep + 1000 + pos)
+# asm 1: movq   1000(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1000(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1000(%rcx,%rdi),%r8
+
+# qhasm: tt2d1 = t if =
+# asm 1: cmove <t=int64#5,<tt2d1=int64#6
+# asm 2: cmove <t=%r8,<tt2d1=%r9
+cmove %r8,%r9
+
+# qhasm: t = *(uint64 *)(basep + 1008 + pos)
+# asm 1: movq   1008(<basep=int64#4,<pos=int64#1),>t=int64#5
+# asm 2: movq   1008(<basep=%rcx,<pos=%rdi),>t=%r8
+movq   1008(%rcx,%rdi),%r8
+
+# qhasm: tt2d2 = t if =
+# asm 1: cmove <t=int64#5,<tt2d2=int64#7
+# asm 2: cmove <t=%r8,<tt2d2=%rax
+cmove %r8,%rax
+
+# qhasm: t = *(uint64 *)(basep + 1016 + pos)
+# asm 1: movq   1016(<basep=int64#4,<pos=int64#1),>t=int64#1
+# asm 2: movq   1016(<basep=%rcx,<pos=%rdi),>t=%rdi
+movq   1016(%rcx,%rdi),%rdi
+
+# qhasm: *(uint64 *)(tp + 64) = tz0
+# asm 1: movq   <z0=int64#2,0(<tp=int64#15)
+# asm 2: movq   <z0=%rbp,64(<tp=%r15)
+movq   %rbp,64(%r15)
+
+# qhasm: *(uint64 *)(tp + 72) = tz1
+# asm 1: movq   <z1=int64#2,0(<tp=int64#15)
+# asm 2: movq   <z1=%r12,72(<tp=%r15)
+movq   %r12,72(%r15)
+
+# qhasm: *(uint64 *)(tp + 80) = tz2
+# asm 1: movq   <z2=int64#2,0(<tp=int64#15)
+# asm 2: movq   <z2=%r13,80(<tp=%r15)
+movq   %r13,80(%r15)
+
+# qhasm: *(uint64 *)(tp + 88) = tz3
+# asm 1: movq   <z3=int64#2,0(<tp=int64#15)
+# asm 2: movq   <z3=%r14,88(<tp=%r15)
+movq   %r14,88(%r15)
+
+# qhasm: tt2d3 = t if =
+# asm 1: cmove <t=int64#1,<tt2d3=int64#8
+# asm 2: cmove <t=%rdi,<tt2d3=%r10
+cmove %rdi,%r10
+
+# qhasm: tt0 = 0
+# asm 1: mov  $0,>tt0=int64#1
+# asm 2: mov  $0,>tt0=%rdi
+mov  $0,%rdi
+
+# qhasm: tt1 = 0
+# asm 1: mov  $0,>tt1=int64#4
+# asm 2: mov  $0,>tt1=%rcx
+mov  $0,%rcx
+
+# qhasm: tt2 = 0
+# asm 1: mov  $0,>tt2=int64#5
+# asm 2: mov  $0,>tt2=%r8
+mov  $0,%r8
+
+# qhasm: tt3 = 0
+# asm 1: mov  $0,>tt3=int64#9
+# asm 2: mov  $0,>tt3=%r11
+mov  $0,%r11
+
+# qhasm: carry? tt0 -= tt2d0
+# asm 1: sub  <tt2d0=int64#2,<tt0=int64#1
+# asm 2: sub  <tt2d0=%rsi,<tt0=%rdi
+sub  %rsi,%rdi
+
+# qhasm: carry? tt1 -= tt2d1 - carry
+# asm 1: sbb  <tt2d1=int64#6,<tt1=int64#4
+# asm 2: sbb  <tt2d1=%r9,<tt1=%rcx
+sbb  %r9,%rcx
+
+# qhasm: carry? tt2 -= tt2d2 - carry
+# asm 1: sbb  <tt2d2=int64#7,<tt2=int64#5
+# asm 2: sbb  <tt2d2=%rax,<tt2=%r8
+sbb  %rax,%r8
+
+# qhasm: carry? tt3 -= tt2d3 - carry
+# asm 1: sbb  <tt2d3=int64#8,<tt3=int64#9
+# asm 2: sbb  <tt2d3=%r10,<tt3=%r11
+sbb  %r10,%r11
+
+# qhasm: subt0 = 0
+# asm 1: mov  $0,>subt0=int64#10
+# asm 2: mov  $0,>subt0=%r12
+mov  $0,%r12
+
+# qhasm: subt1 = 38
+# asm 1: mov  $38,>subt1=int64#11
+# asm 2: mov  $38,>subt1=%r13
+mov  $38,%r13
+
+# qhasm: subt1 = subt0 if !carry
+# asm 1: cmovae <subt0=int64#10,<subt1=int64#11
+# asm 2: cmovae <subt0=%r12,<subt1=%r13
+cmovae %r12,%r13
+
+# qhasm: carry? tt0 -= subt1
+# asm 1: sub  <subt1=int64#11,<tt0=int64#1
+# asm 2: sub  <subt1=%r13,<tt0=%rdi
+sub  %r13,%rdi
+
+# qhasm: carry? tt1 -= subt0 - carry
+# asm 1: sbb  <subt0=int64#10,<tt1=int64#4
+# asm 2: sbb  <subt0=%r12,<tt1=%rcx
+sbb  %r12,%rcx
+
+# qhasm: carry? tt2 -= subt0 - carry
+# asm 1: sbb  <subt0=int64#10,<tt2=int64#5
+# asm 2: sbb  <subt0=%r12,<tt2=%r8
+sbb  %r12,%r8
+
+# qhasm: carry? tt3 -= subt0 - carry
+# asm 1: sbb  <subt0=int64#10,<tt3=int64#9
+# asm 2: sbb  <subt0=%r12,<tt3=%r11
+sbb  %r12,%r11
+
+# qhasm: subt0 = subt1 if carry
+# asm 1: cmovc <subt1=int64#11,<subt0=int64#10
+# asm 2: cmovc <subt1=%r13,<subt0=%r12
+cmovc %r13,%r12
+
+# qhasm: tt0 -= subt0
+# asm 1: sub  <subt0=int64#10,<tt0=int64#1
+# asm 2: sub  <subt0=%r12,<tt0=%rdi
+sub  %r12,%rdi
+
+# qhasm: signed<? b - 0
+# asm 1: cmp  $0,<b=int64#3
+# asm 2: cmp  $0,<b=%rdx
+cmp  $0,%rdx
+
+# qhasm: tt2d0 = tt0 if signed<
+# asm 1: cmovl <tt0=int64#1,<tt2d0=int64#2
+# asm 2: cmovl <tt0=%rdi,<tt2d0=%rsi
+cmovl %rdi,%rsi
+
+# qhasm: tt2d1 = tt1 if signed<
+# asm 1: cmovl <tt1=int64#4,<tt2d1=int64#6
+# asm 2: cmovl <tt1=%rcx,<tt2d1=%r9
+cmovl %rcx,%r9
+
+# qhasm: tt2d2 = tt2 if signed<
+# asm 1: cmovl <tt2=int64#5,<tt2d2=int64#7
+# asm 2: cmovl <tt2=%r8,<tt2d2=%rax
+cmovl %r8,%rax
+
+# qhasm: tt2d3 = tt3 if signed<
+# asm 1: cmovl <tt3=int64#9,<tt2d3=int64#8
+# asm 2: cmovl <tt3=%r11,<tt2d3=%r10
+cmovl %r11,%r10
+
+# qhasm: *(uint64 *)(tp + 96) = tt2d0
+# asm 1: movq   <tt2d0=int64#2,96(<tp=int64#13)
+# asm 2: movq   <tt2d0=%rsi,96(<tp=%r15)
+movq   %rsi,96(%r15)
+
+# qhasm: *(uint64 *)(tp + 104) = tt2d1
+# asm 1: movq   <tt2d1=int64#6,104(<tp=int64#13)
+# asm 2: movq   <tt2d1=%r9,104(<tp=%r15)
+movq   %r9,104(%r15)
+
+# qhasm: *(uint64 *)(tp + 112) = tt2d2
+# asm 1: movq   <tt2d2=int64#7,112(<tp=int64#13)
+# asm 2: movq   <tt2d2=%rax,112(<tp=%r15)
+movq   %rax,112(%r15)
+
+# qhasm: *(uint64 *)(tp + 120) = tt2d3
+# asm 1: movq   <tt2d3=int64#8,120(<tp=int64#13)
+# asm 2: movq   <tt2d3=%r10,120(<tp=%r15)
+movq   %r10,120(%r15)
+
+# qhasm:   caller1 = caller1_stack
+# asm 1: movq <caller1_stack=stack64#1,>caller1=int64#9
+# asm 2: movq <caller1_stack=0(%rsp),>caller1=%r11
+movq 0(%rsp),%r11
+
+# qhasm:   caller2 = caller2_stack
+# asm 1: movq <caller2_stack=stack64#2,>caller2=int64#10
+# asm 2: movq <caller2_stack=8(%rsp),>caller2=%r12
+movq 8(%rsp),%r12
+
+# qhasm:   caller3 = caller3_stack
+# asm 1: movq <caller3_stack=stack64#3,>caller3=int64#11
+# asm 2: movq <caller3_stack=16(%rsp),>caller3=%r13
+movq 16(%rsp),%r13
+
+# qhasm:   caller4 = caller4_stack
+# asm 1: movq <caller4_stack=stack64#4,>caller4=int64#12
+# asm 2: movq <caller4_stack=24(%rsp),>caller4=%r14
+movq 24(%rsp),%r14
+
+# qhasm:   caller5 = caller5_stack
+# asm 1: movq <caller5_stack=stack64#5,>caller5=int64#13
+# asm 2: movq <caller5_stack=32(%rsp),>caller5=%r15
+movq 32(%rsp),%r15
+
+# qhasm:   caller6 = caller6_stack
+# asm 1: movq <caller6_stack=stack64#6,>caller6=int64#14
+# asm 2: movq <caller6_stack=40(%rsp),>caller6=%rbx
+movq 40(%rsp),%rbx
+
+# qhasm:   caller7 = caller7_stack
+# asm 1: movq <caller7_stack=stack64#7,>caller7=int64#15
+# asm 2: movq <caller7_stack=48(%rsp),>caller7=%rbp
+movq 48(%rsp),%rbp
+
+# qhasm: leave
+add %r11,%rsp
+mov %rdi,%rax
+mov %rsi,%rdx
+ret

--- a/src/amd64/amd64-64-24k.c
+++ b/src/amd64/amd64-64-24k.c
@@ -1,0 +1,76 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file from bench.cr.yp.to/supercop.html (2017-07-25):
+//     Daniel J. Bernstein
+//     Niels Duif
+//     Tanja Lange
+//     lead: Peter Schwabe
+//     Bo-Yin Yang
+
+#include <stddef.h>
+#include "fe25519.h"
+#include "ge25519.h"
+
+/* constants below can be found in various fles in ed25519/amd64-64-24k */
+
+/* d */
+static const fe25519 ecd = {{0x75EB4DCA135978A3, 0x00700A4D4141D8AB, 0x8CC740797779E898, 0x52036CEE2B6FFE73}};
+/* 2*d */
+static const fe25519 ec2d = {{0xEBD69B9426B2F146, 0x00E0149A8283B156, 0x198E80F2EEF3D130, 0xA406D9DC56DFFCE7}};
+/* sqrt(-1) */
+static const fe25519 sqrtm1 = {{0xC4EE1B274A0EA0B0, 0x2F431806AD2FE478, 0x2B4D00993DFBD7A7, 0x2B8324804FC1DF0B}};
+
+/* taken from loop in ed25519/amd64-64-24k/ge25519_double_scalarmult.c */
+static void ge25519_p1p1_to_pniels(ge25519_pniels* out, ge25519_p1p1 const* in)
+{
+  ge25519_p1p1_to_p3((ge25519_p3*)out, in);
+  const fe25519 d = out->ysubx;
+  fe25519_sub(&(out->ysubx), &(out->xaddy), &(out->ysubx));
+  fe25519_add(&(out->xaddy), &(out->xaddy), &d);
+  fe25519_mul(&(out->t2d), &(out->t2d), &ec2d);
+}
+
+#define choose_tp crypto_sign_ed25519_amd64_64_choose_tp
+#include "amd64.c.inc"
+
+int monero_crypto_amd64_64_24k_ge25519_scalarmult(char* out, char const* pub, char const* sec)
+{
+  return scalarmult(out, pub, sec);
+}
+
+int monero_crypto_amd64_64_24k_generate_key_derivation(char* out, char const* tx_pub, char const* view_sec)
+{
+  return generate_key_derivation(out, tx_pub, view_sec);
+}
+
+int monero_crypto_amd64_64_24k_generate_subaddress_public_key(char* out, char const* output_pub, char const* special_sec)
+{
+  return generate_subaddress_public_key(out, output_pub, special_sec);
+}
+

--- a/src/amd64/amd64.c.inc
+++ b/src/amd64/amd64.c.inc
@@ -1,0 +1,221 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Parts of this file from biench.cr.yp.to/supercop.html (2017-02-25):
+//     Daniel J. Bernstein
+//     Niels Duif
+//     Tanja Lange
+//     lead: Peter Schwabe
+//     Bo-Yin Yang
+
+#include <string.h>
+#include "ge25519.h"
+
+extern void choose_tp(ge25519_pniels *t, unsigned long long pos, signed long long b, const ge25519_pniels *base_multiples);
+
+/* return 0 on success, -1 otherwise. Taken from
+ed25519/amd64-51-30k/ge25519_unpackneg.c - the negation is removed. */
+static int unpack_vartime(ge25519_p3 *r, const unsigned char p[32])
+{
+  fe25519 t, chk, num, den, den2, den4, den6;
+  unsigned char par = p[31] >> 7;
+
+  fe25519_setint(&r->z,1);
+  fe25519_unpack(&r->y, p); 
+  fe25519_square(&num, &r->y); /* x = y^2 */
+  fe25519_mul(&den, &num, &ecd); /* den = dy^2 */
+  fe25519_sub(&num, &num, &r->z); /* x = y^2-1 */
+  fe25519_add(&den, &r->z, &den); /* den = dy^2+1 */
+
+  /* Computation of sqrt(num/den)
+     1.: computation of num^((p-5)/8)*den^((7p-35)/8) = (num*den^7)^((p-5)/8)
+  */
+  fe25519_square(&den2, &den);
+  fe25519_square(&den4, &den2);
+  fe25519_mul(&den6, &den4, &den2);
+  fe25519_mul(&t, &den6, &num);
+  fe25519_mul(&t, &t, &den);
+
+  fe25519_pow2523(&t, &t);
+  /* 2. computation of r->x = t * num * den^3
+  */
+  fe25519_mul(&t, &t, &num);
+  fe25519_mul(&t, &t, &den);
+  fe25519_mul(&t, &t, &den);
+  fe25519_mul(&r->x, &t, &den);
+
+  /* 3. Check whether sqrt computation gave correct result, multiply by sqrt(-1) if not:
+  */
+  fe25519_square(&chk, &r->x);
+  fe25519_mul(&chk, &chk, &den);
+  if (!fe25519_iseq_vartime(&chk, &num))
+    fe25519_mul(&r->x, &r->x, &sqrtm1);
+
+  /* 4. Now we have one of the two square roots, except if input was not a square
+  */
+  fe25519_square(&chk, &r->x);
+  fe25519_mul(&chk, &chk, &den);
+  if (!fe25519_iseq_vartime(&chk, &num))
+    return -1;
+
+  /* 5. Choose the desired square root according to parity:
+  */
+  if(fe25519_getparity(&r->x) == (1-par)) // only change from original function was `!=` -> `==`
+    fe25519_neg(&r->x, &r->x);
+
+  fe25519_mul(&r->t, &r->x, &r->y);
+  return 0;
+}
+
+static void p3_to_pniels(ge25519_pniels* out, ge25519_p3 const* src)
+{
+  fe25519_sub(&out->ysubx, &src->y, &src->x);
+  fe25519_add(&out->xaddy, &src->x, &src->y);
+  fe25519_mul(&out->t2d, &src->t, &ec2d);
+  out->z = src->z;
+}
+
+static void negate(ge25519* out)
+{
+  fe25519_neg(&out->x, &out->x);
+  fe25519_neg(&out->t, &out->t);
+}
+
+// similar to loops in existing implementation, but uses dynamic table instead of fixed `G`.
+static void scalarmult_p1p1(ge25519_p1p1* r, ge25519_pniels const* base, char const* sec)
+{
+  signed char b[64];
+  ge25519_pniels t;
+  ge25519_p3 tp3;
+
+  sc25519 s;
+  memcpy(s.v, sec, sizeof(s));
+  sc25519_window4(b, &s);
+
+  // set neutral
+  fe25519_setint(&tp3.x, 0);
+  fe25519_setint(&tp3.y, 1);
+  fe25519_setint(&tp3.t, 0);
+  fe25519_setint(&tp3.z, 1);
+  // end set neutral
+
+  for (int i = 63; /* break below*/ ; --i)
+  {
+    choose_tp(&t, (unsigned long long) 0, (signed long long) b[i], base);
+    ge25519_pnielsadd_p1p1(r, &tp3, &t);
+
+    if (i == 0) break;
+
+    ge25519_p1p1_to_p2((ge25519_p2*)&tp3, r);
+
+    ge25519_dbl_p1p1(r,(ge25519_p2 *)&tp3);
+    ge25519_p1p1_to_p2((ge25519_p2 *)&tp3, r);
+    ge25519_dbl_p1p1(r,(ge25519_p2 *)&tp3);
+    ge25519_p1p1_to_p2((ge25519_p2 *)&tp3, r);
+    ge25519_dbl_p1p1(r,(ge25519_p2 *)&tp3);
+    ge25519_p1p1_to_p2((ge25519_p2 *)&tp3, r);
+    ge25519_dbl_p1p1(r,(ge25519_p2 *)&tp3);
+    ge25519_p1p1_to_p3(&tp3, r);
+  }
+}
+
+// _similar_ to ge_scalarmult in src/crypto/crypto-ops.c
+static void base_precomp(ge25519_pniels* base, ge25519_p3 const* r)
+{
+  ge25519_p1p1 tp1p1;
+
+  p3_to_pniels(&base[0], r);
+  for (int i = 0; i < 7; ++i)
+  {
+    ge25519_pnielsadd_p1p1(&tp1p1, r, &base[i]);
+    ge25519_p1p1_to_pniels(&base[i + 1], &tp1p1);
+  }
+}
+
+static int scalarmult(char* out, char const* pub, char const* sec)
+{
+  ge25519 unpacked;
+  ge25519_pniels base[8];
+  ge25519_p1p1 tp1p1;
+  if (unpack_vartime(&unpacked, (unsigned char const*)pub) != 0)
+    return -1;
+
+  base_precomp(base, &unpacked);
+  scalarmult_p1p1(&tp1p1, base, sec);
+  ge25519_p1p1_to_p3(&unpacked, &tp1p1);
+
+  ge25519_pack((unsigned char*)out, &unpacked);
+  return 0;
+}
+
+static int generate_key_derivation(char* out, char const* tx_pub, char const* view_sec)
+{
+  ge25519 unpacked;
+  ge25519_pniels base[8];
+  ge25519_p1p1 tp1p1;
+  if (unpack_vartime(&unpacked, (unsigned char const*)tx_pub) != 0)
+    return -1;
+
+  base_precomp(base, &unpacked);
+  scalarmult_p1p1(&tp1p1, base, view_sec);
+
+  // non-standard, monero specific - guarantees point is in ed25519 group
+  ge25519_p1p1_to_p2((ge25519_p2*)&unpacked, &tp1p1);
+  ge25519_dbl_p1p1(&tp1p1,(ge25519_p2 *)&unpacked);
+  ge25519_p1p1_to_p2((ge25519_p2 *)&unpacked, &tp1p1);
+  ge25519_dbl_p1p1(&tp1p1,(ge25519_p2 *)&unpacked);
+  ge25519_p1p1_to_p2((ge25519_p2 *)&unpacked, &tp1p1);
+  ge25519_dbl_p1p1(&tp1p1,(ge25519_p2 *)&unpacked);
+  ge25519_p1p1_to_p3(&unpacked, &tp1p1);
+
+  ge25519_pack((unsigned char*)out, &unpacked);
+  return 0;
+}
+
+static void generate_subaddress_public_key_base(char* out, ge25519 const* output_pub, char const* special_sec)
+{
+  ge25519 p1;
+  sc25519 p2;
+
+  memcpy(p2.v, special_sec, sizeof(p2.v));
+  ge25519_scalarmult_base(&p1, &p2);
+  negate(&p1); // ge25519_sub is not provided by these libraries
+  ge25519_add(&p1, output_pub, &p1);
+  ge25519_pack((unsigned char*)out, &p1);
+}
+
+static int generate_subaddress_public_key(char* out, char const* output_pub, char const* special_sec)
+{
+  ge25519 p;
+  if (unpack_vartime(&p, (unsigned char const*)output_pub) != 0)
+    return -1;
+
+  generate_subaddress_public_key_base(out, &p, special_sec);
+  return 0;
+}
+

--- a/src/crypto.h.in
+++ b/src/crypto.h.in
@@ -1,0 +1,38 @@
+// Copyright (c) 2020, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MONERO_CRYPTO_H
+#define MONERO_CRYPTO_H
+
+#include "monero/crypto/@MONERO_CRYPTO_LIBRARY@.h"
+
+#define monero_crypto_ge25519_scalarmult monero_crypto_@MONERO_CRYPTO_NAMESPACE@_ge25519_scalarmult
+#define monero_crypto_generate_key_derivation monero_crypto_@MONERO_CRYPTO_NAMESPACE@_generate_key_derivation
+#define monero_crypto_generate_subaddress_public_key monero_crypto_@MONERO_CRYPTO_NAMESPACE@_generate_subaddress_public_key
+
+#endif // MONERO_CRYPTO_H


### PR DESCRIPTION
Reviewers, please look at updated README.md first which explains the goals of this PR in particular.

-------------------

On ryzen 3900x the speedup for `crypto::generate_key_derivation` is ~153% and the speedup for `crypto::derive_subaddress_public_key` is ~141%. When looking at the total crypto operations for a standard 2-output transaction, this results in a ~147% speedup on this same CPU. On a recentish Intel laptop the speedup for 2-output transactions is ~140%.

I have yet to do a speed comparison in wallet2 directly. I would not expect an exact ~140%-192% speedup because there are other factors limiting the scanning. The crypto operations are fairly dominant in the profile graphs though, so there will be decent gains. I will publish numbers at some point, unless it appears fairly quickly that this PR is going to be rejected.

----------------

@kenshi84 @hyc @stoffu @xiphon @moneromooo-monero there is somewhat advanced ASM in this PR. The ASM included here is _adapted_ from the existing ASM in `crypto_sign/ed25519/<variant>/choose_t.s`. That assembly was written where `z == 1` since the scalarmult tables could be pre-generated. The ASM here took the existing ASM and added support for the `z` value in the group element with an unused x86-64 register. Diffing against the originals will show this.

The other options: (1) drop constant-time nature possibly leaking viewkey in some contexts or (2) 7 additional field inversions when generating the table for scalarmult. This table is needed when doing the ECDH for every tx (ed25519 typically does not have ECDH against arbitrary points, only `G`). Pinging @SarangNoether @surae-noether too.

---------------

@moneromooo-monero @moneroexamples This was specifically designed to be usable in outside projects. I _believe_ openmonero and monero-light-wallet-server can drop the dependency on internal `monero-project/monero` libraries if they use ZMQ-JSON-RPC and add: (1) keccak, the (2) custom varint serialization, and (3) support for parsing `tx_extra`. The first two are required for `crypto::derivation_to_scalar` which is not provided by these sets of changes. The **other** big blocker for those projects is portability - @moneroexamples please let me know if you are interested and we can gauge support for adding `ref10` to this repo. This will not be used by the default monero-wallet, but would provide portability for the wallet servers.

The other advantage to outside projects is all of this code should be easier to audit than the internal monero crypto library - the ref10 library should require zero changes and these amd64 variants only had position-independent changes to the ASM.