### PR TITLE
Remedy some GCC warnings

### DIFF
--- a/crypto_sign/ed25519/amd64-64-24k/ge25519_scalarmult_base.c
+++ b/crypto_sign/ed25519/amd64-64-24k/ge25519_scalarmult_base.c
@@ -12,7 +12,9 @@ static const ge25519_niels ge25519_base_multiples_niels[] = {
 };
 
 /* d */
+#ifdef SMALLTABLES
 static const fe25519 ecd = {{0x75EB4DCA135978A3, 0x00700A4D4141D8AB, 0x8CC740797779E898, 0x52036CEE2B6FFE73}};
+#endif
 
 void ge25519_scalarmult_base(ge25519_p3 *r, const sc25519 *s)
 {

--- a/crypto_sign/ed25519/amd64-64-24k/sc25519.h
+++ b/crypto_sign/ed25519/amd64-64-24k/sc25519.h
@@ -55,7 +55,7 @@ void sc25519_mul_shortsc(sc25519 *r, const sc25519 *x, const shortsc25519 *y);
 /* Convert s into a representation of the form \sum_{i=0}^{63}r[i]2^(4*i)
  * with r[i] in {-8,...,7}
  */
-void sc25519_window4(signed char r[85], const sc25519 *s);
+void sc25519_window4(signed char r[64], const sc25519 *s);
 
 void sc25519_slide(signed char r[256], const sc25519 *s, int swindowsize);
 


### PR DESCRIPTION
The `#ifdef SMALLTABLES` change eliminates the unused variable warning, and the changes to the `sc25519_window4` prototype silences the `-Wstringop-overflow=` warnings in GCC.

The prototype seems to be wrong b/c it requires an array of size 85, but the function definition only uses 64 bytes,  the caller expects it only needs 64 bytes, and the 85 seems to be a copy/paste issue from window3 (Props to @moneromooo-monero for finding that)

Closes #7 and #8 